### PR TITLE
Update type definition to align with JavaScript implementation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,14 +14,7 @@ type MultipartHandler = (
     mimetype: string,
 ) => void;
 
-declare module "fastify" {
-    interface FastifyRequest<HttpRequest> {
-        isMultipart: () => boolean;
-        multipart: (handler: MultipartHandler, next: (err: Error) => void) => busboy.Busboy;
-    }
-}
-
-declare const fastifyMultipart: fastify.Plugin<Server, IncomingMessage, ServerResponse, {
+type MultipartOptions = {
     /**
      * Append the multipart parameters to the body object
      */
@@ -68,6 +61,15 @@ declare const fastifyMultipart: fastify.Plugin<Server, IncomingMessage, ServerRe
          */
         headerPairs?: number;
     }
-}>;
+};
+
+declare module "fastify" {
+    interface FastifyRequest<HttpRequest> {
+        isMultipart: () => boolean;
+        multipart: (handler: MultipartHandler, next: (err: Error) => void, options: MultipartOptions) => busboy.Busboy;
+    }
+}
+
+declare const fastifyMultipart: fastify.Plugin<Server, IncomingMessage, ServerResponse, MultipartOptions>;
 
 export = fastifyMultipart;

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ type MultipartOptions = {
 declare module "fastify" {
     interface FastifyRequest<HttpRequest> {
         isMultipart: () => boolean;
-        multipart: (handler: MultipartHandler, next: (err: Error) => void, options: MultipartOptions) => busboy.Busboy;
+        multipart: (handler: MultipartHandler, next: (err: Error) => void, options?: MultipartOptions) => busboy.Busboy;
     }
 }
 


### PR DESCRIPTION
The `multipart` method of `FastifyRequest` has 3 parameters, but the third parameter `options` is missing in the type definition file.