### PR TITLE
Fix default export to commonjs export. Fixes #76.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,7 @@ type MultipartHandler = (
     mimetype: string,
 ) => void;
 
-export interface BodyEntry {
+interface BodyEntry {
     data: Buffer,
     filename: string,
     encoding: string,
@@ -78,4 +78,4 @@ declare const fastifyMultipart: fastify.Plugin<Server, IncomingMessage, ServerRe
     }
 }>;
 
-export default fastifyMultipart;
+export = fastifyMultipart;

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -1,37 +1,46 @@
 import * as fastify from 'fastify'
-import fastifyMultipart from '../..'
+import fastifyMultipart = require('../..')
 
 /** TODO This import must be decommented when this
  *  https://github.com/standard/standard/pull/1101
  *  PR will be merged and released
-*/
+ */
 // import { Readable } from 'stream'
 
-const app = fastify()
+const runServer = async () => {
+  const app = fastify()
 
-app.register(fastifyMultipart, {
-  addToBody: true,
-  sharedSchemaId: 'sharedId',
-  // stream should be of type streams.Readable
-  // body should be of type fastifyMulipart.Record<string, BodyEntry>
-  onFile: (fieldName: string, stream: any, filename: string, encoding: string, mimetype: string, body: Record<string, any>) => {
-    console.log(fieldName, stream, filename, encoding, mimetype, body)
-  },
-  limits: {
-    fieldNameSize: 200,
-    fieldSize: 200,
-    fields: 200,
-    fileSize: 200,
-    files: 2,
-    headerPairs: 200
-  }
-})
-
-app.get('/path', (request) => {
-  const isMultiPart = request.isMultipart()
-  request.multipart((field, file, filename, encoding, mimetype) => {
-    console.log(field, file, filename, encoding, mimetype, isMultiPart)
-  }, (err) => {
-    throw err
+  app.register(fastifyMultipart, {
+    addToBody: true,
+    sharedSchemaId: 'sharedId',
+    // stream should be of type streams.Readable
+    // body should be of type fastifyMulipart.Record<string, BodyEntry>
+    onFile: (fieldName: string, stream: any, filename: string, encoding: string, mimetype: string, body: Record<string, any>) => {
+      console.log(fieldName, stream, filename, encoding, mimetype, body)
+    },
+    limits: {
+      fieldNameSize: 200,
+      fieldSize: 200,
+      fields: 200,
+      fileSize: 200,
+      files: 2,
+      headerPairs: 200
+    }
   })
-})
+
+  app.get('/path', (request) => {
+    const isMultiPart = request.isMultipart()
+    request.multipart((field, file, filename, encoding, mimetype) => {
+      console.log(field, file, filename, encoding, mimetype, isMultiPart)
+    }, (err) => {
+      throw err
+    })
+  })
+
+  await app.ready()
+}
+
+runServer().then(
+  console.log.bind(console, 'Success'),
+  console.error.bind(console, 'Error')
+)


### PR DESCRIPTION
As discussed in the issue, changing the default export. Also removing the export that isn't compatible with this format.

I also changed the test to make the server start so you can verify that it works by running something like `ts-node test/types/index.ts`.