### PR TITLE
#102 - Dont attach file to body if the limit has been reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ function handler (field, file, filename, encoding, mimetype) {
 }              
 ```
 
+Note, if the file size limit is exceeded the file will not be attached to the body. 
+
 Additionally, you can pass per-request options to the req.multipart function
 
 ```js

--- a/index.js
+++ b/index.js
@@ -55,9 +55,7 @@ function defaultConsumer (field, file, filename, encoding, mimetype, body) {
   const fileData = []
   const lastFile = body[field][body[field].length - 1]
   file.on('data', data => { fileData.push(data) })
-  file.on('limit', () => {
-    lastFile.limit = true
-  })
+  file.on('limit', () => { lastFile.limit = true })
   file.on('end', () => {
     if (!lastFile.limit) {
       lastFile.data = Buffer.concat(fileData)
@@ -144,7 +142,7 @@ function fastifyMultipart (fastify, options, done) {
     })
 
     stream.on('finish', function () {
-      log.debug('finished multipart parsing', files)
+      log.debug('finished multipart parsing')
       if (!completed && count === files) {
         completed = true
         setImmediate(done)

--- a/index.js
+++ b/index.js
@@ -55,9 +55,15 @@ function defaultConsumer (field, file, filename, encoding, mimetype, body) {
   const fileData = []
   const lastFile = body[field][body[field].length - 1]
   file.on('data', data => { fileData.push(data) })
-  file.on('limit', () => { lastFile.limit = true })
+  file.on('limit', () => {
+    lastFile.limit = true
+  })
   file.on('end', () => {
-    lastFile.data = Buffer.concat(fileData)
+    if (!lastFile.limit) {
+      lastFile.data = Buffer.concat(fileData)
+    } else {
+      delete lastFile.data
+    }
   })
 }
 
@@ -138,7 +144,7 @@ function fastifyMultipart (fastify, options, done) {
     })
 
     stream.on('finish', function () {
-      log.debug('finished multipart parsing')
+      log.debug('finished multipart parsing', files)
       if (!completed && count === files) {
         completed = true
         setImmediate(done)

--- a/index.js
+++ b/index.js
@@ -54,13 +54,13 @@ function attachToBody (options, req, reply, next) {
 function defaultConsumer (field, file, filename, encoding, mimetype, body) {
   const fileData = []
   const lastFile = body[field][body[field].length - 1]
-  file.on('data', data => { fileData.push(data) })
+  file.on('data', data => { if (!lastFile.limit) { fileData.push(data) } })
   file.on('limit', () => { lastFile.limit = true })
   file.on('end', () => {
     if (!lastFile.limit) {
       lastFile.data = Buffer.concat(fileData)
     } else {
-      delete lastFile.data
+      lastFile.data = undefined
     }
   })
 }

--- a/test/append-body.test.js
+++ b/test/append-body.test.js
@@ -63,6 +63,49 @@ test('addToBody option', t => {
   })
 })
 
+test('addToBody with limit exceeded', t => {
+  t.plan(5)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { addToBody: true, limits: { fileSize: 1 } })
+
+  fastify.post('/', function (req, reply) {
+    t.type(req.body.myFile[0].limit, true)
+    t.type(req.body.myFile[0].data, undefined)
+
+    reply.send('ok')
+  })
+
+  fastify.listen(0, function () {
+    // request
+    var form = new FormData()
+    var opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    var req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 200)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+
+    var rs = fs.createReadStream(filePath)
+    form.append('myFile', rs)
+    pump(form, req, function (err) {
+      t.error(err, 'client pump: no err')
+    })
+  })
+})
+
 test('addToBody option and multiple files', t => {
   t.plan(7)
 

--- a/test/append-body.test.js
+++ b/test/append-body.test.js
@@ -72,8 +72,8 @@ test('addToBody with limit exceeded', t => {
   fastify.register(multipart, { addToBody: true, limits: { fileSize: 1 } })
 
   fastify.post('/', function (req, reply) {
-    t.type(req.body.myFile[0].limit, true)
-    t.type(req.body.myFile[0].data, undefined)
+    t.equals(req.body.myFile[0].limit, true)
+    t.equals(req.body.myFile[0].data, undefined)
 
     reply.send('ok')
   })


### PR DESCRIPTION
I was having issues with the test "should call finished when both files are pumped" locally but had no changes to affect it. Seems the check on filesCount happens before the callback in pump() is getting executed.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
