### PR TITLE
Add a check if request is multipart on the preValidation hook when `attachFieldsToBody` is true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,6 +133,9 @@ function fastifyMultipart (fastify, options = {}, done) {
       })
     }
     fastify.addHook('preValidation', async function (req, reply) {
+      if (!req.isMultipart()) {
+        return
+      }
       for await (const part of req.parts()) {
         req.body = part.fields
         if (part.file) {


### PR DESCRIPTION
Fix #150.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
