### PR TITLE
rethrow busboy error when storing files on disk, add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you do set upload limits, be sure to catch the error. An error or exception w
 **Note**: if the file stream that is provided by `data.file` is not consumed (like in the example below with the usage of pump) the promise won't be fulfilled at the end of the multipart processing.
 This behavior is inherited from [busboy](https://github.com/mscdex/busboy).
 
-**Note**: if you set a `fileSize` limit and you want to know if the file limit was reached you can listen to `data.file.on('limit')` or check at the of the stream the property `data.file.truncated`. 
+**Note**: if you set a `fileSize` limit and you want to know if the file limit was reached you can listen to `data.file.on('limit')` or check at the end of the stream the property `data.file.truncated`. 
 
 ```js
 try {

--- a/README.md
+++ b/README.md
@@ -160,8 +160,6 @@ fastify.post('/upload/raw/any', async function (req, reply) {
 
 This will store all files in the operating system default directory for temporary files. As soon as the response ends all files are removed.
 
-**Note**: if you set a `fileSize` limit `req.saveRequestFiles()` is able to throw an `RequestFileTooLargeError` error.
-
 ```js
 fastify.post('/upload/files', async function (req, reply) {
   // stores files to tmp dir and return files
@@ -174,6 +172,21 @@ fastify.post('/upload/files', async function (req, reply) {
   files[0].fields // other parsed parts
 
   reply.send()
+})
+```
+
+## Handle file size limitation
+
+If you set a `fileSize` limit `req.saveRequestFiles()` is able to throw an `RequestFileTooLargeError` error.
+
+```js
+fastify.post('/upload/files', async function (req, reply) {
+  try {
+    const files = await req.saveRequestFiles({ limits: { fileSize: 17000 } })
+    reply.send()
+  } catch (error) {
+    // error instanceof fastify.multipartErrors.RequestFileTooLargeError
+  }
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ If you do set upload limits, be sure to catch the error. An error or exception w
 **Note**: if the file stream that is provided by `data.file` is not consumed (like in the example below with the usage of pump) the promise won't be fulfilled at the end of the multipart processing.
 This behavior is inherited from [busboy](https://github.com/mscdex/busboy).
 
+**Note**: if you set a `fileSize` limit and you want to know if the file limit was reached you can listen to `data.file.on('limit')` or check at the of the stream the property `data.file.truncated`. 
+
 ```js
 try {
   const data = await req.file()
@@ -157,6 +159,8 @@ fastify.post('/upload/raw/any', async function (req, reply) {
 ## Upload files to disk and work with temporary file paths
 
 This will store all files in the operating system default directory for temporary files. As soon as the response ends all files are removed.
+
+**Note**: if you set a `fileSize` limit `req.saveRequestFiles()` will throw an `RequestFileTooLargeError` error.
 
 ```js
 fastify.post('/upload/files', async function (req, reply) {

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ fastify.post('/upload/raw/any', async function (req, reply) {
 
 This will store all files in the operating system default directory for temporary files. As soon as the response ends all files are removed.
 
-**Note**: if you set a `fileSize` limit `req.saveRequestFiles()` will throw an `RequestFileTooLargeError` error.
+**Note**: if you set a `fileSize` limit `req.saveRequestFiles()` is able to throw an `RequestFileTooLargeError` error.
 
 ```js
 fastify.post('/upload/files', async function (req, reply) {

--- a/index.js
+++ b/index.js
@@ -450,14 +450,12 @@ function fastifyMultipart (fastify, options = {}, done) {
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
-      delete err.part.file
       return Promise.reject(err)
     }
 
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part
-      delete err.part.file
 
       if (file.listenerCount('error') > 0) {
         file.emit('error', err)

--- a/index.js
+++ b/index.js
@@ -449,14 +449,12 @@ function fastifyMultipart (fastify, options = {}, done) {
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
-      delete err.part.file
       return Promise.reject(err)
     }
 
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part
-      delete err.part.file
 
       if (file.listenerCount('error') > 0) {
         file.emit('error', err)
@@ -487,6 +485,7 @@ function fastifyMultipart (fastify, options = {}, done) {
         this.tmpUploads.push(filepath)
         requestFiles.push({ ...file, filepath })
       } catch (error) {
+        await sendToWormhole(file.file)
         try {
           await unlink(filepath)
         } catch (error) {

--- a/index.js
+++ b/index.js
@@ -466,8 +466,6 @@ function fastifyMultipart (fastify, options = {}, done) {
           logger.error('fileLimit: suppressed file stream error, %s', err.messsage)
         })
       }
-      // ignore all data
-      sendToWormhole(file)
     })
 
     return part
@@ -485,6 +483,8 @@ function fastifyMultipart (fastify, options = {}, done) {
         this.tmpUploads.push(filepath)
         requestFiles.push({ ...file, filepath })
       } catch (error) {
+        // ensure that stream is consumed, any error is suppressed
+        await sendToWormhole(file.file)
         try {
           await unlink(filepath)
         } catch (error) {

--- a/index.js
+++ b/index.js
@@ -329,6 +329,8 @@ function fastifyMultipart (fastify, options = {}, done) {
 
     const bb = busboy(busboyOptions)
 
+    request.bb = bb
+
     request.on('close', cleanup)
 
     bb
@@ -436,7 +438,6 @@ function fastifyMultipart (fastify, options = {}, done) {
       bb.removeListener('field', onField)
       bb.removeListener('file', onFile)
       bb.removeListener('close', cleanup)
-      request.unpipe(bb)
     }
 
     return parts

--- a/index.js
+++ b/index.js
@@ -467,7 +467,7 @@ function fastifyMultipart (fastify, options = {}, done) {
         })
       }
       // ignore all data
-      file.resume()
+      sendToWormhole(file)
     })
 
     return part

--- a/index.js
+++ b/index.js
@@ -449,12 +449,14 @@ function fastifyMultipart (fastify, options = {}, done) {
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
       return Promise.reject(err)
     }
 
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
 
       if (file.listenerCount('error') > 0) {
         file.emit('error', err)
@@ -485,7 +487,6 @@ function fastifyMultipart (fastify, options = {}, done) {
         this.tmpUploads.push(filepath)
         requestFiles.push({ ...file, filepath })
       } catch (error) {
-        await sendToWormhole(file.file)
         try {
           await unlink(filepath)
         } catch (error) {

--- a/index.js
+++ b/index.js
@@ -175,7 +175,6 @@ function fastifyMultipart (fastify, options = {}, done) {
 
   fastify.decorateRequest('isMultipart', isMultipart)
   fastify.decorateRequest('tmpUploads', null)
-  fastify.decorateRequest('busboy', null)
 
   // legacy
   fastify.decorateRequest('multipart', handleLegacyMultipartApi)
@@ -330,8 +329,6 @@ function fastifyMultipart (fastify, options = {}, done) {
 
     const bb = busboy(busboyOptions)
 
-    this.busboy = bb
-
     request.on('close', cleanup)
 
     bb
@@ -450,8 +447,6 @@ function fastifyMultipart (fastify, options = {}, done) {
       // ensure that stream is consumed, any error is suppressed
       await sendToWormhole(file)
 
-      request.raw.unpipe(request.busboy)
-
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
@@ -476,7 +471,6 @@ function fastifyMultipart (fastify, options = {}, done) {
       }
       // ignore all data
       file.resume()
-      request.raw.unpipe(request.busboy)
     })
 
     return part

--- a/index.js
+++ b/index.js
@@ -453,10 +453,6 @@ function fastifyMultipart (fastify, options = {}, done) {
       return Promise.reject(err)
     }
 
-    file.once('error', (err) => {
-      logger.error(err, 'file error')
-    })
-
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part

--- a/index.js
+++ b/index.js
@@ -430,15 +430,8 @@ function fastifyMultipart (fastify, options = {}, done) {
     }
 
     function cleanup () {
-      bb.removeListener('field', onField)
-      bb.removeListener('file', onFile)
-      bb.removeListener('close', cleanup)
-      bb.removeListener('end', cleanup)
-      bb.removeListener('error', onEnd)
-      bb.removeListener('partsLimit', onEnd)
-      bb.removeListener('filesLimit', onEnd)
-      bb.removeListener('fieldsLimit', onEnd)
-      bb.removeListener('finish', onEnd)
+      request.unpipe(bb)
+      bb.removeAllListeners()
     }
 
     return parts

--- a/index.js
+++ b/index.js
@@ -336,6 +336,7 @@ function fastifyMultipart (fastify, options = {}, done) {
       .on('file', onFile)
       .on('close', cleanup)
       .on('error', onEnd)
+      .on('end', onEnd)
       .on('finish', onEnd)
 
     bb.on('partsLimit', function () {
@@ -424,18 +425,19 @@ function fastifyMultipart (fastify, options = {}, done) {
 
     function onEnd (error) {
       cleanup()
-      bb.removeListener('finish', onEnd)
-      bb.removeListener('error', onEnd)
       ch(error || lastError)
     }
 
     function cleanup () {
-      // keep finish listener to wait all data flushed
-      // keep error listener to wait stream error
-      request.removeListener('close', cleanup)
       bb.removeListener('field', onField)
       bb.removeListener('file', onFile)
       bb.removeListener('close', cleanup)
+      bb.removeListener('end', cleanup)
+      bb.removeListener('error', onEnd)
+      bb.removeListener('partsLimit', onEnd)
+      bb.removeListener('filesLimit', onEnd)
+      bb.removeListener('fieldsLimit', onEnd)
+      bb.removeListener('finish', onEnd)
     }
 
     return parts

--- a/index.js
+++ b/index.js
@@ -455,14 +455,14 @@ function fastifyMultipart (fastify, options = {}, done) {
           err.part = file
           throw err
         }
-      } catch (error) {
+      } catch (err) {
         try {
           await unlink(filepath)
-        } catch (error) {
-          this.log.debug('saveRequestFiles: could not delete file, %s', error.messsage)
+        } catch (err) {
+          this.log.debug({ err }, 'could not delete file')
         }
 
-        throw error
+        throw err
       }
     }
 
@@ -477,7 +477,7 @@ function fastifyMultipart (fastify, options = {}, done) {
       try {
         await unlink(filepath)
       } catch (error) {
-        this.log.error(error)
+        this.log.error(error, 'could not delete file')
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -449,12 +449,14 @@ function fastifyMultipart (fastify, options = {}, done) {
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
       return Promise.reject(err)
     }
 
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
 
       if (file.listenerCount('error') > 0) {
         file.emit('error', err)

--- a/index.js
+++ b/index.js
@@ -453,6 +453,10 @@ function fastifyMultipart (fastify, options = {}, done) {
       return Promise.reject(err)
     }
 
+    file.once('error', (err) => {
+      logger.error(err, 'file error')
+    })
+
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part

--- a/index.js
+++ b/index.js
@@ -436,6 +436,7 @@ function fastifyMultipart (fastify, options = {}, done) {
       bb.removeListener('field', onField)
       bb.removeListener('file', onFile)
       bb.removeListener('close', cleanup)
+      request.unpipe(bb)
     }
 
     return parts

--- a/index.js
+++ b/index.js
@@ -450,12 +450,14 @@ function fastifyMultipart (fastify, options = {}, done) {
       // throw on consumer side
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
       return Promise.reject(err)
     }
 
     file.once('limit', () => {
       const err = new RequestFileTooLargeError()
       err.part = part
+      delete err.part.file
 
       if (file.listenerCount('error') > 0) {
         file.emit('error', err)

--- a/index.js
+++ b/index.js
@@ -466,6 +466,8 @@ function fastifyMultipart (fastify, options = {}, done) {
           logger.error('fileLimit: suppressed file stream error, %s', err.messsage)
         })
       }
+      // ignore all data
+      file.resume()
     })
 
     return part
@@ -483,8 +485,6 @@ function fastifyMultipart (fastify, options = {}, done) {
         this.tmpUploads.push(filepath)
         requestFiles.push({ ...file, filepath })
       } catch (error) {
-        // ensure that stream is consumed, any error is suppressed
-        await sendToWormhole(file.file)
         try {
           await unlink(filepath)
         } catch (error) {

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -6,39 +6,60 @@ const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
 const http = require('http')
-const path = require('path')
-const fs = require('fs')
+const crypto = require('crypto')
+const { Readable } = require('readable-stream')
 const stream = require('stream')
 const pump = util.promisify(stream.pipeline)
+const sendToWormhole = require('stream-wormhole')
 const EventEmitter = require('events')
 const { once } = EventEmitter
 
-const filePath = path.join(__dirname, '../README.md')
-
-test('should throw fileSize limitation error on small payload', async function (t) {
+test('should emit fileSize limitation error during streaming', async function (t) {
   t.plan(3)
 
   const fastify = Fastify({ logger: { level: 'debug' } })
   t.tearDown(fastify.close.bind(fastify))
+  const hashInput = crypto.createHash('sha256')
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     t.ok(req.isMultipart())
-
-    try {
-      await req.file({ limits: { fileSize: 2 } })
-      reply.code(200).send()
-    } catch (error) {
-      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+    const part = await req.file({ limits: { fileSize: 16500 } })
+    await sendToWormhole(part.file)
+    if (part.file.truncated) {
       reply.code(500).send()
+    } else {
+      reply.code(200).send()
     }
   })
 
   await fastify.listen(0)
 
   // request
-  const form = new FormData()
+  const knownLength = 1024 * 1024 // 1MB
+  let total = knownLength
+  const form = new FormData({ maxDataSize: total })
+  const rs = new Readable({
+    read (n) {
+      if (n > total) {
+        n = total
+      }
+
+      var buf = Buffer.alloc(n).fill('x')
+      hashInput.update(buf)
+      this.push(buf)
+
+      total -= n
+
+      if (total === 0) {
+        t.pass('finished generating')
+        hashInput.end()
+        this.push(null)
+      }
+    }
+  })
+
   const opts = {
     protocol: 'http:',
     hostname: 'localhost',
@@ -49,7 +70,11 @@ test('should throw fileSize limitation error on small payload', async function (
   }
 
   const req = http.request(opts)
-  form.append('upload', fs.createReadStream(filePath))
+  form.append('upload', rs, {
+    filename: 'random-data',
+    contentType: 'binary/octect-stream',
+    knownLength
+  })
 
   pump(form, req)
 

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const util = require('util')
+const test = require('tap').test
+const FormData = require('form-data')
+const Fastify = require('fastify')
+const multipart = require('..')
+const http = require('http')
+const path = require('path')
+const fs = require('fs')
+const stream = require('stream')
+const pump = util.promisify(stream.pipeline)
+const EventEmitter = require('events')
+const { once } = EventEmitter
+
+const filePath = path.join(__dirname, '../README.md')
+
+test('should throw fileSize limitation error on small payload', async function (t) {
+  t.plan(3)
+
+  const fastify = Fastify({ logger: { level: 'debug' } })
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.file({ limits: { fileSize: 2 } })
+      reply.code(200).send()
+    } catch (error) {
+      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      reply.code(500).send()
+    }
+  })
+
+  await fastify.listen(0)
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+
+  pump(form, req)
+
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 500)
+    res.resume()
+    await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
+})

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -174,10 +174,14 @@ test('should throw on file limit error', async function (t) {
 
   pump(form, req)
 
-  const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 500)
-  res.resume()
-  await once(res, 'end')
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 500)
+    res.resume()
+    await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
 })
 
 test('should throw on file limit error, after highWaterMark', async function (t) {
@@ -246,10 +250,14 @@ test('should throw on file limit error, after highWaterMark', async function (t)
 
   pump(form, req)
 
-  const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 500)
-  res.resume()
-  await once(res, 'end')
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 500)
+    res.resume()
+    await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
 })
 
 test('should store file on disk, remove on response error, serial', async function (t) {

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -171,7 +171,6 @@ test('should throw on file limit error', async function (t) {
   }
   const req = http.request(opts)
   form.append('upload', fs.createReadStream(filePath))
-  form.append('upload2', fs.createReadStream(filePath))
 
   pump(form, req)
 
@@ -239,7 +238,6 @@ test('should throw on file limit error, after highWaterMark', async function (t)
   }
 
   const req = http.request(opts)
-  form.append('upload', fs.createReadStream(filePath))
   form.append('upload2', rs, {
     filename: 'random-data',
     contentType: 'binary/octect-stream',

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -10,7 +10,6 @@ const crypto = require('crypto')
 const { Readable } = require('readable-stream')
 const path = require('path')
 const fs = require('fs')
-const sendToWormhole = require('stream-wormhole')
 const { access } = require('fs').promises
 const stream = require('stream')
 const pump = util.promisify(stream.pipeline)
@@ -136,7 +135,7 @@ test('should throw on file limit error, after highWaterMark', function (t) {
   t.plan(6)
 
   const hashInput = crypto.createHash('sha256')
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: { level: 'debug' } })
   t.tearDown(fastify.close.bind(fastify))
 
   fastify.register(multipart)
@@ -150,8 +149,6 @@ test('should throw on file limit error, after highWaterMark', function (t) {
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       t.equal(error.part.fieldname, 'upload2')
-      // we have to wait until the file was flushed
-      await sendToWormhole(error.part.file)
       reply.code(500).send()
     }
   })

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -125,9 +125,7 @@ test('should throw on file limit error', function (t) {
 
     try {
       await pump(form, req)
-    } catch (error) {
-      t.error(error, 'formData request pump: no err')
-    }
+    } catch (error) {}
   })
 })
 
@@ -135,7 +133,7 @@ test('should throw on file limit error, after highWaterMark', function (t) {
   t.plan(6)
 
   const hashInput = crypto.createHash('sha256')
-  const fastify = Fastify({ logger: { level: 'debug' } })
+  const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
 
   fastify.register(multipart)
@@ -203,9 +201,7 @@ test('should throw on file limit error, after highWaterMark', function (t) {
 
     try {
       await pump(form, req)
-    } catch (error) {
-      t.error(error, 'formData request pump: no err')
-    }
+    } catch (error) {}
   })
 })
 

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -93,11 +93,11 @@ test('should throw on file limit error', function (t) {
 
     try {
       await req.saveRequestFiles({ limits: { fileSize: 500 } })
-      reply.code(500).send()
+      reply.code(200).send()
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       t.equal(error.part.fieldname, 'upload')
-      reply.code(200).send()
+      reply.code(500).send()
     }
   })
 
@@ -114,7 +114,7 @@ test('should throw on file limit error', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.equal(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
         t.pass('res ended successfully')
@@ -145,11 +145,11 @@ test('should throw on file limit error, after highWaterMark', function (t) {
 
     try {
       await req.saveRequestFiles({ limits: { fileSize: 17000 } })
-      reply.code(500).send()
+      reply.code(200).send()
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       t.equal(error.part.fieldname, 'upload2')
-      reply.code(200).send()
+      reply.code(500).send()
     }
   })
 
@@ -194,7 +194,7 @@ test('should throw on file limit error, after highWaterMark', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.equal(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
         t.pass('res ended successfully')

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -6,6 +6,8 @@ const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
 const http = require('http')
+const crypto = require('crypto')
+const { Readable } = require('readable-stream')
 const path = require('path')
 const fs = require('fs')
 const { access } = require('fs').promises
@@ -69,6 +71,135 @@ test('should store file on disk, remove on response', function (t) {
       })
     })
     form.append('upload', fs.createReadStream(filePath))
+
+    try {
+      await pump(form, req)
+    } catch (error) {
+      t.error(error, 'formData request pump: no err')
+    }
+  })
+})
+
+test('should throw on file limit error', function (t) {
+  t.plan(5)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.saveRequestFiles({ limits: { fileSize: 500 } })
+      reply.code(500).send()
+    } catch (error) {
+      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      t.equal(error.part.fieldname, 'upload')
+      reply.code(200).send()
+    }
+  })
+
+  fastify.listen(0, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 200)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('upload', fs.createReadStream(filePath))
+    form.append('upload2', fs.createReadStream(filePath))
+
+    try {
+      await pump(form, req)
+    } catch (error) {
+      t.error(error, 'formData request pump: no err')
+    }
+  })
+})
+
+test('should throw on file limit error, after highWaterMark', function (t) {
+  t.plan(6)
+
+  const hashInput = crypto.createHash('sha256')
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.saveRequestFiles({ limits: { fileSize: 17000 } })
+      reply.code(500).send()
+    } catch (error) {
+      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      t.equal(error.part.fieldname, 'upload2')
+      reply.code(200).send()
+    }
+  })
+
+  fastify.listen(0, async function () {
+    // request
+    const knownLength = 1024 * 1024 // 1MB
+    let total = knownLength
+    const form = new FormData({ maxDataSize: total })
+    const rs = new Readable({
+      read (n) {
+        if (n > total) {
+          n = total
+        }
+
+        var buf = Buffer.alloc(n).fill('x')
+        hashInput.update(buf)
+        this.push(buf)
+
+        total -= n
+
+        if (total === 0) {
+          t.pass('finished generating')
+          hashInput.end()
+          this.push(null)
+        }
+      }
+    })
+    // form.append('upload', fs.createReadStream(filePath))
+    form.append('upload2', rs, {
+      filename: 'random-data',
+      contentType: 'binary/octect-stream',
+      knownLength
+    })
+
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 200)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
 
     try {
       await pump(form, req)

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -10,6 +10,7 @@ const crypto = require('crypto')
 const { Readable } = require('readable-stream')
 const path = require('path')
 const fs = require('fs')
+const sendToWormhole = require('stream-wormhole')
 const { access } = require('fs').promises
 const stream = require('stream')
 const pump = util.promisify(stream.pipeline)
@@ -149,6 +150,8 @@ test('should throw on file limit error, after highWaterMark', function (t) {
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       t.equal(error.part.fieldname, 'upload2')
+      // we have to wait until the file was flushed
+      await sendToWormhole(error.part.file)
       reply.code(500).send()
     }
   })

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -177,7 +177,7 @@ test('should throw on file limit error, after highWaterMark', function (t) {
         }
       }
     })
-    // form.append('upload', fs.createReadStream(filePath))
+    form.append('upload', fs.createReadStream(filePath))
     form.append('upload2', rs, {
       filename: 'random-data',
       contentType: 'binary/octect-stream',

--- a/test/multipart-small-stream.test.js
+++ b/test/multipart-small-stream.test.js
@@ -6,8 +6,6 @@ const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
 const http = require('http')
-const path = require('path')
-const fs = require('fs')
 const crypto = require('crypto')
 const { Readable } = require('readable-stream')
 const stream = require('stream')
@@ -16,56 +14,6 @@ const sendToWormhole = require('stream-wormhole')
 const eos = util.promisify(stream.finished)
 const EventEmitter = require('events')
 const { once } = EventEmitter
-
-const filePath = path.join(__dirname, '../README.md')
-
-test('should throw fileSize limitation error on small payload', async function (t) {
-  t.plan(3)
-
-  const fastify = Fastify({ logger: { level: 'debug' } })
-  t.tearDown(fastify.close.bind(fastify))
-
-  fastify.register(multipart)
-
-  fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
-
-    try {
-      await req.file({ limits: { fileSize: 2 } })
-      reply.code(200).send()
-    } catch (error) {
-      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
-      reply.code(500).send()
-    }
-  })
-
-  await fastify.listen(0)
-
-  // request
-  const form = new FormData()
-  const opts = {
-    protocol: 'http:',
-    hostname: 'localhost',
-    port: fastify.server.address().port,
-    path: '/',
-    headers: form.getHeaders(),
-    method: 'POST'
-  }
-
-  const req = http.request(opts)
-  form.append('upload', fs.createReadStream(filePath))
-
-  pump(form, req)
-
-  try {
-    const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
-    res.resume()
-    await once(res, 'end')
-  } catch (error) {
-    t.error(error, 'request')
-  }
-})
 
 test('should emit fileSize limitation error during streaming', async function (t) {
   t.plan(4)

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -13,7 +13,6 @@ const { Readable } = require('readable-stream')
 const stream = require('stream')
 const pump = util.promisify(stream.pipeline)
 const sendToWormhole = require('stream-wormhole')
-const eos = util.promisify(stream.finished)
 const EventEmitter = require('events')
 const { once } = EventEmitter
 
@@ -83,7 +82,7 @@ test('should emit fileSize limitation error during streaming', async function (t
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       // We need to wait before the stream is drained and the busboy firing 'onEnd' event
-      await eos(part.file)
+      await sendToWormhole(part.file)
       reply.code(500).send()
     }
   })
@@ -134,75 +133,6 @@ test('should emit fileSize limitation error during streaming', async function (t
 
   const [res] = await once(req, 'response')
   t.equal(res.statusCode, 500)
-  res.resume()
-  await once(res, 'end')
-})
-
-test('should ignore fileSize limitation error when no error handler was set', async function (t) {
-  t.plan(3)
-
-  const fastify = Fastify()
-  t.tearDown(fastify.close.bind(fastify))
-  const hashInput = crypto.createHash('sha256')
-
-  fastify.register(multipart)
-
-  fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
-
-    const part = await req.file({ limits: { fileSize: 16500 } })
-    part.file.resume()
-    // don't add error listener
-    await eos(part.file, { error: false })
-    reply.code(200).send()
-  })
-
-  await fastify.listen(0)
-
-  // request
-  const knownLength = 1024 * 1024 // 1MB
-  let total = knownLength
-  const form = new FormData({ maxDataSize: total })
-  const rs = new Readable({
-    read (n) {
-      if (n > total) {
-        n = total
-      }
-
-      var buf = Buffer.alloc(n).fill('x')
-      hashInput.update(buf)
-      this.push(buf)
-
-      total -= n
-
-      if (total === 0) {
-        t.pass('finished generating')
-        hashInput.end()
-        this.push(null)
-      }
-    }
-  })
-
-  const opts = {
-    protocol: 'http:',
-    hostname: 'localhost',
-    port: fastify.server.address().port,
-    path: '/',
-    headers: form.getHeaders(),
-    method: 'POST'
-  }
-
-  const req = http.request(opts)
-  form.append('upload', rs, {
-    filename: 'random-data',
-    contentType: 'binary/octect-stream',
-    knownLength
-  })
-
-  pump(form, req)
-
-  const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
 })

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -88,7 +88,6 @@ test('should emit fileSize limitation error during streaming', async function (t
       await sendToWormhole(part.file, true)
       reply.code(200).send()
     } catch (error) {
-      req.raw.unpipe(req.raw.bb)
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       reply.code(500).send()
     }

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -22,7 +22,7 @@ const filePath = path.join(__dirname, '../README.md')
 test('should throw fileSize limitation error on small payload', async function (t) {
   t.plan(4)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: { level: 'debug' } })
   t.tearDown(fastify.close.bind(fastify))
 
   fastify.register(multipart)
@@ -73,7 +73,7 @@ test('should throw fileSize limitation error on small payload', async function (
 test('should emit fileSize limitation error during streaming', async function (t) {
   t.plan(5)
 
-  const fastify = Fastify()
+  const fastify = Fastify({ logger: { level: 'debug' } })
   t.tearDown(fastify.close.bind(fastify))
   const hashInput = crypto.createHash('sha256')
 

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -143,8 +143,12 @@ test('should emit fileSize limitation error during streaming', async function (t
 
   pump(form, req)
 
-  const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 500)
-  res.resume()
-  await once(res, 'end')
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 500)
+    res.resume()
+    await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
 })

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -71,7 +71,7 @@ test('should throw fileSize limitation error on small payload', async function (
 })
 
 test('should emit fileSize limitation error during streaming', async function (t) {
-  t.plan(5)
+  t.plan(4)
 
   const fastify = Fastify({ logger: { level: 'debug' } })
   t.tearDown(fastify.close.bind(fastify))
@@ -89,12 +89,6 @@ test('should emit fileSize limitation error during streaming', async function (t
       reply.code(200).send()
     } catch (error) {
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
-      try {
-        // We need to wait before the stream is drained and the busboy firing 'onEnd' event
-        await eos(part.file)
-      } catch (error) {
-        t.ok(error, 'eos error')
-      }
       reply.code(500).send()
     }
   })

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -88,6 +88,7 @@ test('should emit fileSize limitation error during streaming', async function (t
       await sendToWormhole(part.file, true)
       reply.code(200).send()
     } catch (error) {
+      req.raw.unpipe(req.raw.bb)
       t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       reply.code(500).send()
     }

--- a/test/multipart-stream.test.js
+++ b/test/multipart-stream.test.js
@@ -137,10 +137,11 @@ test('should emit fileSize limitation error during streaming', async function (t
 
   pump(form, req)
 
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 500)
+  res.resume()
+
   try {
-    const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
-    res.resume()
     await once(res, 'end')
   } catch (error) {
     t.error(error, 'request')


### PR DESCRIPTION
Fix #160 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
