### PR TITLE
fix issue that in multipart handler might miss fields

### DIFF
--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -544,6 +544,7 @@ test('should receive all fields', async function (t) {
   t.plan(11)
 
   const original = fs.readFileSync(filePath, 'utf8')
+  const immediate = util.promisify(setImmediate)
 
   const fastify = Fastify()
   t.tearDown(fastify.close.bind(fastify))
@@ -571,7 +572,7 @@ test('should receive all fields', async function (t) {
             t.equal(buf.toString(), original)
           })
         )
-        await new Promise(setImmediate)
+        await immediate()
       }
 
       recvField[part.fieldname] = true

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -540,7 +540,7 @@ test('should also work with multipartIterator', function (t) {
   })
 })
 
-test('should receive all fields', async function (t) {
+test('should not miss fields if part handler takes much time than formdata parsing', async function (t) {
   t.plan(11)
 
   const original = fs.readFileSync(filePath, 'utf8')


### PR DESCRIPTION
This is to fix one issue that I found in my project, not sure whether this behaviour is intended or not.

Basically, I found that in some cases, it's possible that onField of busyboy will be trigger multiple times before user read the parsed lastValue, this will cause some field in formdata are missing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
