### PR TITLE
Add correct type for non-file value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,9 @@ export interface MultipartFields {
     [x: string]: Multipart | Multipart[];
 }
 
-export interface Multipart {
+export type Multipart<T = true> = T extends true ? MultipartFile : MultipartValue<T>;
+
+interface MultipartFile {
   toBuffer: () => Promise<Buffer>,
   file: NodeJS.ReadableStream,
   filepath: string,
@@ -32,6 +34,10 @@ export interface Multipart {
   encoding: string,
   mimetype: string,
   fields: MultipartFields
+}
+
+interface MultipartValue<T> {
+  value: T
 }
 
 interface MultipartErrors {

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,5 +1,6 @@
 import fastify from 'fastify'
-import fastifyMultipart, {Multipart, MultipartFields} from '..'
+import fastifyMultipart from '..'
+import { Multipart, MultipartFields } from '..'
 import * as util from 'util'
 import { pipeline } from 'stream'
 import * as fs from 'fs'

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -1,10 +1,9 @@
 import fastify from 'fastify'
-import fastifyMultipart from '..'
-import { MultipartFields } from '..'
+import fastifyMultipart, {Multipart, MultipartFields} from '..'
 import * as util from 'util'
 import { pipeline } from 'stream'
 import * as fs from 'fs'
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 
 const pump = util.promisify(pipeline)
 
@@ -56,6 +55,25 @@ const runServer = async () => {
     await pump(data.file, fs.createWriteStream(data.filename))
 
     reply.send()
+  })
+
+  // Multiple fields including scalar values
+  app.post<{Body: {file: Multipart, foo: Multipart<string>}}>('/upload/stringvalue', async (req, reply) => {
+    expectError(req.body.foo.file);
+    expectType<string>(req.body.foo.value);
+
+    expectType<NodeJS.ReadableStream>(req.body.file.file)
+    expectError(req.body.file.value);
+    reply.send();
+  })
+
+  app.post<{Body: {file: Multipart, num: Multipart<number>}}>('/upload/stringvalue', async (req, reply) => {
+    expectType<number>(req.body.num.value);
+    reply.send();
+
+    // file is a file
+    expectType<NodeJS.ReadableStream>(req.body.file.file)
+    expectError(req.body.file.value);
   })
 
   // busboy


### PR DESCRIPTION
Allow user to declare a field as a non-file value with a generic
`Multipart<T>` to set the correct type of the value.

Closes #162
