### PR TITLE
fix(185): saveRequestFiles works with large file

### DIFF
--- a/index.js
+++ b/index.js
@@ -358,6 +358,11 @@ function fastifyMultipart (fastify, options, done) {
       onError(new FieldsLimitError())
     })
 
+    // TODO: Won't need after https://github.com/mscdex/busboy/pull/237/files
+    if (bb._writableState.autoDestroy) {
+      bb._writableState.autoDestroy = false
+    }
+
     request.pipe(bb)
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated) {


### PR DESCRIPTION
Fixes https://github.com/fastify/fastify-multipart/issues/185

- Implemented the solution suggested in https://github.com/fastify/fastify-multipart/issues/185#issuecomment-726197792
- Added coverage for the same

Note: We might not need this when https://github.com/mscdex/busboy/pull/237/files gets merged.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
