### PR TITLE
Move @types/busboy to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
+    "@types/busboy": "^0.2.3",
     "busboy": "^0.3.1",
     "deepmerge": "^4.2.2",
     "end-of-stream": "^1.4.4",
@@ -15,7 +16,6 @@
   },
   "devDependencies": {
     "@types/node": "^14.0.27",
-    "@types/busboy": "^0.2.3",
     "@typescript-eslint/parser": "^4.0.0",
     "climem": "^1.0.3",
     "eslint": "^7.7.0",


### PR DESCRIPTION
I can't use this package in Typescript, because every time I try to build my project via `tsc`, compiler shows an error that package 'busboy' in `index.d.ts` was not found.

I'm not sure if this change is correct or not, But I think it's better to consider `index.d.ts` types dependencies as dependency (not dev-dependency)

Thanks!

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
