### PR TITLE
fix: file size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,14 @@ fastify.post('/upload/files', async function (req, reply) {
 
 ## Handle file size limitation
 
-If you set a `fileSize` limit `req.saveRequestFiles()` is able to throw an `RequestFileTooLargeError` error.
+If you set a `fileSize` limit, it is able to throw an `RequestFileTooLargeError` error when limit reached.
 
 ```js
 fastify.post('/upload/files', async function (req, reply) {
   try {
+    //const file = await req.file({ limits: { fileSize: 17000 } })
+    //const files = await req.files({ limits: { fileSize: 17000 } })
+    //const parts = await req.parts({ limits: { fileSize: 17000 } })
     const files = await req.saveRequestFiles({ limits: { fileSize: 17000 } })
     reply.send()
   } catch (error) {
@@ -192,21 +195,18 @@ fastify.post('/upload/files', async function (req, reply) {
 })
 ```
 
-If you enable `throwFileSizeLimit` to `true`, it will throw an `RequestFileTooLargeError` error when you call any of the below actions.
+If you want to fallback to the handling before `4.0.0`, you can disable the throwing behavior by passing `throwFileSizeLimit`.
+Note: It will not affect the behavior of `saveRequestFiles()`
 
 ```js
-// globally enable
-fastify.register(fastifyMultipart, { throwFileSizeLimit: true })
+// globally disable
+fastify.register(fastifyMultipart, { throwFileSizeLimit: false })
 
 fastify.post('/upload/file', async function (req, reply) {
-  try {
-    const file = await req.file({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
-    //const files = await req.files({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
-    //const parts = await req.parts({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
-    reply.send()
-  } catch (error) {
-    // error instanceof fastify.multipartErrors.RequestFileTooLargeError
-  }
+  const file = await req.file({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  //const files = await req.files({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  //const parts = await req.parts({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  reply.send()
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ fastify.register(fastifyMultipart, { throwFileSizeLimit: true })
 fastify.post('/upload/file', async function (req, reply) {
   try {
     const file = await req.file({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
-    //const files = await req.files({ limits: { fileSize: 17000 } })
-    //const parts = await req.parts({ limits: { fileSize: 17000 } })
+    //const files = await req.files({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
+    //const parts = await req.parts({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
     reply.send()
   } catch (error) {
     // error instanceof fastify.multipartErrors.RequestFileTooLargeError

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ fastify.post('/upload/file', async function (req, reply) {
   const file = await req.file({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
   //const files = await req.files({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
   //const parts = await req.parts({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  //const files = await req.saveRequestFiles({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
   reply.send()
 })
 ```

--- a/README.md
+++ b/README.md
@@ -192,6 +192,24 @@ fastify.post('/upload/files', async function (req, reply) {
 })
 ```
 
+If you enable `throwFileSizeLimit` to `true`, it will throw an `RequestFileTooLargeError` error when you call any of the below actions.
+
+```js
+// globally enable
+fastify.register(fastifyMultipart, { throwFileSizeLimit: true })
+
+fastify.post('/upload/file', async function (req, reply) {
+  try {
+    const file = await req.file({ throwFileSizeLimit: true, limits: { fileSize: 17000 } })
+    //const files = await req.files({ limits: { fileSize: 17000 } })
+    //const parts = await req.parts({ limits: { fileSize: 17000 } })
+    reply.send()
+  } catch (error) {
+    // error instanceof fastify.multipartErrors.RequestFileTooLargeError
+  }
+})
+```
+
 ## Parse all fields and assign them to the body
 
 This allows you to parse all fields automatically and assign them to the `request.body`. By default files are accumulated in memory (Be careful!) to buffer objects. Uncaught errors are [handled](https://github.com/fastify/fastify/blob/master/docs/Hooks.md#manage-errors-from-a-hook) by fastify.

--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,11 @@ export interface FastifyMultipartOptions {
     sharedSchemaId?: string;
 
     /**
+     * Allow throwing error when file size limit reached.
+     */
+    throwFileSizeLimit?: boolean
+
+    /**
      * Manage the file stream like you need
      */
     onFile?: (fieldName: string, stream: Readable, filename: string, encoding: string, mimetype: string, body: Record<string, BodyEntry>) => void | Promise<void>;

--- a/index.js
+++ b/index.js
@@ -174,9 +174,6 @@ function fastifyMultipart (fastify, options, done) {
   fastify.decorateRequest(kMultipartHandler, handleMultipart)
 
   fastify.decorateRequest('parts', getMultipartIterator)
-  // keeping multipartIterator to avoid bumping a major
-  // TODO remove on 4.x
-  fastify.decorateRequest('multipartIterator', getMultipartIterator)
 
   fastify.decorateRequest('isMultipart', isMultipart)
   fastify.decorateRequest('tmpUploads', null)

--- a/index.js
+++ b/index.js
@@ -149,6 +149,11 @@ function fastifyMultipart (fastify, options, done) {
     })
   }
 
+  let throwFileSizeLimit = true
+  if (typeof options.throwFileSizeLimit === 'boolean') {
+    throwFileSizeLimit = options.throwFileSizeLimit
+  }
+
   const PartsLimitError = createError('FST_PARTS_LIMIT', 'reach parts limit', 413)
   const FilesLimitError = createError('FST_FILES_LIMIT', 'reach files limit', 413)
   const FieldsLimitError = createError('FST_FIELDS_LIMIT', 'reach fields limit', 413)
@@ -400,7 +405,11 @@ function fastifyMultipart (fastify, options, done) {
         return
       }
 
-      if (opts.throwFileSizeLimit || options.throwFileSizeLimit) {
+      if (typeof opts.throwFileSizeLimit === 'boolean') {
+        throwFileSizeLimit = opts.throwFileSizeLimit
+      }
+
+      if (throwFileSizeLimit) {
         file.on('limit', function () {
           onError(new RequestFileTooLargeError())
         })

--- a/index.js
+++ b/index.js
@@ -400,6 +400,12 @@ function fastifyMultipart (fastify, options, done) {
         return
       }
 
+      if (opts.throwFileSizeLimit || options.throwFileSizeLimit) {
+        file.on('limit', function () {
+          onError(new RequestFileTooLargeError())
+        })
+      }
+
       const value = {
         fieldname: name,
         filename,

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "scripts": {
     "lint": "standard | snazzy",
-    "unit": "tap test/**/*.test.js test/*.test.js -t 60",
+    "unit": "tap 'test/**/*.test.js' -t 90",
     "typescript": "tsd",
     "test": "npm run lint && npm run unit && npm run typescript",
-    "coverage": "tap test/**/*.test.js test/*.test.js --coverage-report=html",
+    "coverage": "tap 'test/**/*.test.js' --coverage-report=html",
     "start": "CLIMEM=8999 node -r climem ./examples/example",
     "climem": "climem 8999 localhost"
   },

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   },
   "scripts": {
     "lint": "standard | snazzy",
-    "unit": "tap 'test/**/*.test.js' -t 90",
+    "unit": "tap \"test/**/*.test.js\" -t 90",
     "typescript": "tsd",
     "test": "npm run lint && npm run unit && npm run typescript",
-    "coverage": "tap 'test/**/*.test.js' --coverage-report=html",
+    "coverage": "tap \"test/**/*.test.js\" --coverage-report=html",
     "start": "CLIMEM=8999 node -r climem ./examples/example",
     "climem": "climem 8999 localhost"
   },

--- a/test/big.test.js
+++ b/test/big.test.js
@@ -25,7 +25,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
   fastify.post('/', async function (req, reply) {
     t.ok(req.isMultipart())
 
-    for await (const part of req.multipartIterator()) {
+    for await (const part of req.parts()) {
       if (part.file) {
         t.equal(part.fieldname, 'upload')
         t.equal(part.filename, 'random-data')

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -14,6 +14,7 @@ const runServer = async () => {
   app.register(fastifyMultipart, {
     addToBody: true,
     sharedSchemaId: 'sharedId',
+    throwFileSizeLimit: false,
     // stream should be of type streams.Readable
     // body should be of type fastifyMulipart.Record<string, BodyEntry>
     onFile: (fieldName: string, stream: any, filename: string, encoding: string, mimetype: string, body: Record<string, any>) => {

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -574,69 +574,6 @@ test('should not throw error due to file size limit exceed - files setting (Defa
   })
 })
 
-test('should also work with multipartIterator', function (t) {
-  t.plan(8)
-
-  const fastify = Fastify()
-  t.tearDown(fastify.close.bind(fastify))
-
-  fastify.register(multipart)
-
-  fastify.post('/', async function (req, reply) {
-    for await (const part of req.multipartIterator()) {
-      if (part.file) {
-        t.equal(part.fieldname, 'upload')
-        t.equal(part.filename, 'README.md')
-        t.equal(part.encoding, '7bit')
-        t.equal(part.mimetype, 'text/markdown')
-        t.ok(part.fields.upload)
-
-        const original = fs.readFileSync(filePath, 'utf8')
-        await pump(
-          part.file,
-          concat(function (buf) {
-            t.equal(buf.toString(), original)
-          })
-        )
-      }
-    }
-
-    reply.code(200).send()
-  })
-
-  fastify.listen(0, async function () {
-    // request
-    const form = new FormData()
-    const opts = {
-      protocol: 'http:',
-      hostname: 'localhost',
-      port: fastify.server.address().port,
-      path: '/',
-      headers: form.getHeaders(),
-      method: 'POST'
-    }
-
-    const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
-      // consume all data without processing
-      res.resume()
-      res.on('end', () => {
-        t.pass('res ended successfully')
-      })
-    })
-    const rs = fs.createReadStream(filePath)
-    form.append('upload', rs)
-    form.append('hello', 'world')
-    form.append('willbe', 'dropped')
-
-    try {
-      await pump(form, req)
-    } catch (error) {
-      t.error(error, 'formData request pump: no err')
-    }
-  })
-})
-
 test('should not miss fields if part handler takes much time than formdata parsing', async function (t) {
   t.plan(11)
 

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -477,6 +477,108 @@ test('should throw error due to partsLimit (The max number of parts (fields + fi
   })
 })
 
+test('should throw error due to file size limit exceed - global setting (Default: false)', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { throwFileSizeLimit: true, limits: { fileSize: 1 } })
+
+  fastify.post('/', async function (req, reply) {
+    try {
+      const parts = await req.files()
+      for await (const part of parts) {
+        t.ok(part.file)
+        await sendToWormhole(part.file)
+      }
+      reply.code(200).send()
+    } catch (error) {
+      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      reply.code(500).send()
+    }
+  })
+
+  fastify.listen(0, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 500)
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('upload', fs.createReadStream(filePath))
+    form.append('upload2', fs.createReadStream(filePath))
+
+    try {
+      await pump(form, req)
+    } catch (error) {
+      t.error(error, 'formData request pump: no err')
+    }
+  })
+})
+
+test('should throw error due to file size limit exceed - files setting (Default: false)', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    try {
+      const parts = await req.files({ throwFileSizeLimit: true, limits: { fileSize: 1 } })
+      for await (const part of parts) {
+        t.ok(part.file)
+        await sendToWormhole(part.file)
+      }
+      reply.code(200).send()
+    } catch (error) {
+      t.true(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      reply.code(500).send()
+    }
+  })
+
+  fastify.listen(0, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 500)
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('upload', fs.createReadStream(filePath))
+    form.append('upload2', fs.createReadStream(filePath))
+
+    try {
+      await pump(form, req)
+    } catch (error) {
+      t.error(error, 'formData request pump: no err')
+    }
+  })
+})
+
 test('should also work with multipartIterator', function (t) {
   t.plan(8)
 


### PR DESCRIPTION
This PR resolve #196 by adding a new option `throwFileSizeLimit`.

The option can be configure in two way:

#### Globally
```JS
fastify.register(fastifyMultipart, { throwFileSizeLimit: false })
```

#### Per Functions
```JS
const file = await req.file({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
const files = await req.files({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
const parts = await req.parts({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
