### PR TITLE
Feature/increase test coverage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare module "fastify" {
         files: (options?: busboy.BusboyConfig) => AsyncIterableIterator<Multipart>
 
         // Disk mode
-        saveRequestFiles: (options?: busboy.BusboyConfig) => Promise<Array<Multipart>>
+        saveRequestFiles: (options?: busboy.BusboyConfig & { toID: () => string }) => Promise<Array<Multipart>>
         cleanRequestFiles: () => Promise<void>
         tmpUploads: Array<Multipart>
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare module "fastify" {
         files: (options?: busboy.BusboyConfig) => AsyncIterableIterator<Multipart>
 
         // Disk mode
-        saveRequestFiles: (options?: busboy.BusboyConfig & { toID: () => string }) => Promise<Array<Multipart>>
+        saveRequestFiles: (options?: busboy.BusboyConfig & { tmpdir: string }) => Promise<Array<Multipart>>
         cleanRequestFiles: () => Promise<void>
         tmpUploads: Array<Multipart>
     }

--- a/index.js
+++ b/index.js
@@ -462,11 +462,12 @@ function fastifyMultipart (fastify, options, done) {
 
   async function saveRequestFiles (options) {
     const requestFiles = []
+    const generateId = (options && options.toID) || toID
 
     const files = await this.files(options)
     this.tmpUploads = []
     for await (const file of files) {
-      const filepath = path.join(os.tmpdir(), toID() + path.extname(file.filename))
+      const filepath = path.join(os.tmpdir(), generateId() + path.extname(file.filename))
       const target = createWriteStream(filepath)
       try {
         await pump(file.file, target)

--- a/index.js
+++ b/index.js
@@ -149,11 +149,6 @@ function fastifyMultipart (fastify, options, done) {
     })
   }
 
-  let throwFileSizeLimit = true
-  if (typeof options.throwFileSizeLimit === 'boolean') {
-    throwFileSizeLimit = options.throwFileSizeLimit
-  }
-
   const PartsLimitError = createError('FST_PARTS_LIMIT', 'reach parts limit', 413)
   const FilesLimitError = createError('FST_FILES_LIMIT', 'reach files limit', 413)
   const FieldsLimitError = createError('FST_FIELDS_LIMIT', 'reach fields limit', 413)
@@ -402,6 +397,7 @@ function fastifyMultipart (fastify, options, done) {
         return
       }
 
+      let throwFileSizeLimit = true
       if (typeof opts.throwFileSizeLimit === 'boolean') {
         throwFileSizeLimit = opts.throwFileSizeLimit
       }

--- a/index.js
+++ b/index.js
@@ -462,12 +462,12 @@ function fastifyMultipart (fastify, options, done) {
 
   async function saveRequestFiles (options) {
     const requestFiles = []
-    const generateId = (options && options.toID) || toID
+    const tmpdir = (options && options.tmpdir) || os.tmpdir()
 
     const files = await this.files(options)
     this.tmpUploads = []
     for await (const file of files) {
-      const filepath = path.join(os.tmpdir(), generateId() + path.extname(file.filename))
+      const filepath = path.join(tmpdir, toID() + path.extname(file.filename))
       const target = createWriteStream(filepath)
       try {
         await pump(file.file, target)

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -11,7 +11,7 @@ const { Readable } = require('readable-stream')
 const path = require('path')
 const fs = require('fs')
 const os = require('os')
-const { access, chmod, rm, open } = require('fs').promises
+const { access, chmod, open, unlink } = require('fs').promises
 const stream = require('stream')
 const EventEmitter = require('events')
 const { once } = EventEmitter
@@ -218,7 +218,7 @@ test('should throw on file save error', async function (t) {
   await open(tempFilePath, 'a') // touch
   await chmod(tempFilePath, '444') // readonly
 
-  t.tearDown(() => rm(tempFilePath))
+  t.tearDown(() => unlink(tempFilePath))
 
   // request
   const form = new FormData()
@@ -269,7 +269,7 @@ test('should throw on request files cleanup error', async function (t) {
     try {
       await req.saveRequestFiles({ toID })
       // temp file saved, remove before the onResponse hook
-      await rm(tempFilePath)
+      await unlink(tempFilePath)
       reply.code(200).send()
     } catch (error) {
       reply.code(500).send()

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -232,7 +232,7 @@ test('should throw on file save error', async function (t) {
   }
 })
 
-test('should not throw on request files cleanup error', async function (t) {
+test('should not throw on request files cleanup error', { skip: process.platform === 'win32' }, async function (t) {
   t.plan(2)
 
   const fastify = Fastify()


### PR DESCRIPTION
Fix #202 Increase the test coverage for the plugin. 

The coverage is:
```
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |    98.85 |    93.27 |      100 |    98.83 |                   |
 index.js |    98.85 |    93.27 |      100 |    98.83 |       272,277,278 |
----------|----------|----------|----------|----------|-------------------|
```

Previously it was:
```
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |    96.56 |    90.29 |      100 |    96.51 |                   |
 index.js |    96.56 |    90.29 |      100 |    96.51 |... 83,480,481,496 |
----------|----------|----------|----------|----------|-------------------|
```

To test the scenarios where temporary files are stored to disk, we needed to be able to predict what the temporary file
name would be. Previously the temp file id was generated by `hexoid`, but now I needed to make the id generation strategy injectable. This way, I can simulate the scenario where the temp file cannot be changed or where the temp file is missing.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
