### PR TITLE
chore: include os name in build name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    name: ${{ matrix.os }} ${{ matrix.node-version }}
+    name: ${{ matrix.os }} Node ${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
-    name: Node ${{ matrix.node-version }}
+    name: ${{ matrix.os }} ${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
To distinguish them, otherwise they're all called Node {something}