### PR TITLE
feat: req.file throws filesize error

### DIFF
--- a/index.js
+++ b/index.js
@@ -504,6 +504,9 @@ function fastifyMultipart (fastify, options, done) {
     let part
     while ((part = await parts()) != null) {
       if (part.file) {
+        if (part.file.truncated) {
+          throw new RequestFileTooLargeError()
+        }
         return part
       }
     }

--- a/index.js
+++ b/index.js
@@ -504,7 +504,8 @@ function fastifyMultipart (fastify, options, done) {
     let part
     while ((part = await parts()) != null) {
       if (part.file) {
-        if (part.file.truncated) {
+        // part.file.truncated is true when a configured file size limit is reached
+        if (part.file.truncated && throwFileSizeLimit) {
           throw new RequestFileTooLargeError()
         }
         return part

--- a/test/multipart-small-stream.test.js
+++ b/test/multipart-small-stream.test.js
@@ -29,11 +29,8 @@ test('should throw fileSize limitation error on small payload', async function (
 
     const part = await req.file({ limits: { fileSize: 2 } })
     await sendToWormhole(part.file)
-    if (part.file.truncated) {
-      reply.code(413).send()
-    } else {
-      reply.code(200).send()
-    }
+
+    reply.code(200).send()
   })
 
   await fastify.listen(0)
@@ -57,6 +54,51 @@ test('should throw fileSize limitation error on small payload', async function (
   try {
     const [res] = await once(req, 'response')
     t.equal(res.statusCode, 413)
+    res.resume()
+    await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
+})
+
+test('should not throw and error when throwFileSizeLimit option is false', async function (t) {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    const part = await req.file({ limits: { fileSize: 2 }, throwFileSizeLimit: false })
+    await sendToWormhole(part.file)
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen(0)
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+
+  pump(form, req)
+
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 200)
     res.resume()
     await once(res, 'end')
   } catch (error) {

--- a/test/multipart-small-stream.test.js
+++ b/test/multipart-small-stream.test.js
@@ -30,7 +30,7 @@ test('should throw fileSize limitation error on small payload', async function (
     const part = await req.file({ limits: { fileSize: 2 } })
     await sendToWormhole(part.file)
     if (part.file.truncated) {
-      reply.code(500).send()
+      reply.code(413).send()
     } else {
       reply.code(200).send()
     }
@@ -56,7 +56,7 @@ test('should throw fileSize limitation error on small payload', async function (
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
+    t.equal(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
   } catch (error) {


### PR DESCRIPTION
Feature proposal:

Allow req.file to throw an error when the file is bigger than the limit

closes #196 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
