### PR TITLE
fix(types): saveRequestFiles option types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -66,7 +66,7 @@ declare module "fastify" {
         files: (options?: busboy.BusboyConfig) => AsyncIterableIterator<Multipart>
 
         // Disk mode
-        saveRequestFiles: (options?: busboy.BusboyConfig & { tmpdir: string }) => Promise<Array<Multipart>>
+        saveRequestFiles: (options?: busboy.BusboyConfig & { tmpdir?: string }) => Promise<Array<Multipart>>
         cleanRequestFiles: () => Promise<void>
         tmpUploads: Array<Multipart>
     }

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -130,6 +130,14 @@ const runServer = async () => {
     reply.send()
   })
 
+  // upload files to disk with busboy options
+  app.post('/upload/files', async function (req, reply) {
+    const options: busboy.BusboyConfig = { limits: { fileSize: 1000 } };
+    await req.saveRequestFiles(options)
+
+    reply.send()
+  })
+
   // access all errors
   app.post('/upload/files', async function (req, reply) {
     const { FilesLimitError } = app.multipartErrors


### PR DESCRIPTION
Make it possible to provide busboy options without having to include tmpdir when calling saveRequestFiles in TypeScript.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
