### PR TITLE
docs: consume req.body in the form of key-value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,9 @@ fastify.register(require('fastify-multipart'), { attachFieldsToBody: true })
 fastify.post('/upload/files', async function (req, reply) {
   const uploadValue = await req.body.upload.toBuffer()  // access files
   const fooValue = await req.body.foo.value           // other fields
+  const body = Object.fromEntries(
+    Object.keys(req.body).map((key) => [key, req.body[key].value])
+  ) // Request body in key-value pairs, like req.body in Express (Node 12+)
 })
 ```
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

The pull request add documentation on how to consume `req.body` in key-value pairs.

This may help new comers from Express.js