### PR TITLE
Remove unnecessary await keywords from documentations, tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ fastify.post('/', async function (req, reply) {
 
 ```js
 fastify.post('/', async function (req, reply) {
-  const parts = await req.files()
+  const parts = req.files()
   for await (const part of parts) {
     await pump(part.file, fs.createWriteStream(part.filename))
   }
@@ -135,7 +135,7 @@ fastify.post('/', async function (req, reply) {
 
 ```js
 fastify.post('/upload/raw/any', async function (req, reply) {
-  const parts = await req.parts()
+  const parts = req.parts()
   for await (const part of parts) {
     if (part.file) {
       await pump(part.file, fs.createWriteStream(part.filename))
@@ -185,10 +185,10 @@ If you set a `fileSize` limit, it is able to throw a `RequestFileTooLargeError` 
 ```js
 fastify.post('/upload/files', async function (req, reply) {
   try {
-    //const file = await req.file({ limits: { fileSize: 17000 } })
-    //const files = await req.files({ limits: { fileSize: 17000 } })
-    //const parts = await req.parts({ limits: { fileSize: 17000 } })
-    const files = await req.saveRequestFiles({ limits: { fileSize: 17000 } })
+    const file = await req.file({ limits: { fileSize: 17000 } })
+    //const files = req.files({ limits: { fileSize: 17000 } })
+    //const parts = req.parts({ limits: { fileSize: 17000 } })
+    //const files = await req.saveRequestFiles({ limits: { fileSize: 17000 } })
     reply.send()
   } catch (error) {
     // error instanceof fastify.multipartErrors.RequestFileTooLargeError
@@ -205,8 +205,8 @@ fastify.register(fastifyMultipart, { throwFileSizeLimit: false })
 
 fastify.post('/upload/file', async function (req, reply) {
   const file = await req.file({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
-  //const files = await req.files({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
-  //const parts = await req.parts({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  //const files = req.files({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
+  //const parts = req.parts({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
   //const files = await req.saveRequestFiles({ throwFileSizeLimit: false, limits: { fileSize: 17000 } })
   reply.send()
 })
@@ -220,8 +220,8 @@ This allows you to parse all fields automatically and assign them to the `reques
 fastify.register(require('fastify-multipart'), { attachFieldsToBody: true })
 
 fastify.post('/upload/files', async function (req, reply) {
-  const uploadValue = await req.body.upload.toBuffer()  // access files
-  const fooValue = await req.body.foo.value           // other fields
+  const uploadValue = await req.body.upload.toBuffer() // access files
+  const fooValue = req.body.foo.value                  // other fields
   const body = Object.fromEntries(
     Object.keys(req.body).map((key) => [key, req.body[key].value])
   ) // Request body in key-value pairs, like req.body in Express (Node 12+)
@@ -238,7 +238,7 @@ async function onFile(part) {
 fastify.register(require('fastify-multipart'), { attachFieldsToBody: true, onFile })
 
 fastify.post('/upload/files', async function (req, reply) {
-  const fooValue = await req.body.foo.value           // other fields
+  const fooValue = req.body.foo.value // other fields
 })
 ```
 

--- a/examples/example.js
+++ b/examples/example.js
@@ -31,7 +31,7 @@ fastify.post('/upload/stream/single-buf', async function (req, reply) {
 })
 
 fastify.post('/upload/stream/files', async function (req, reply) {
-  const parts = await req.files()
+  const parts = req.files()
   for await (const part of parts) {
     await pump(part.file, fs.createWriteStream(part.filename))
   }
@@ -39,7 +39,7 @@ fastify.post('/upload/stream/files', async function (req, reply) {
 })
 
 fastify.post('/upload/raw/any', async function (req, reply) {
-  const parts = await req.parts()
+  const parts = req.parts()
   for await (const part of parts) {
     if (part.file) {
       await pump(part.file, fs.createWriteStream(part.filename))

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -96,7 +96,7 @@ const runServer = async () => {
 
   // handle multiple file streams
   app.post('/', async (req, reply) => {
-    const parts = await req.files()
+    const parts = req.files()
     for await (const part of parts) {
       await pump(part.file, fs.createWriteStream(part.filename))
     }
@@ -105,7 +105,7 @@ const runServer = async () => {
 
   // handle multiple file streams and fields
   app.post('/upload/raw/any', async function (req, reply) {
-    const parts = await req.parts()
+    const parts = req.parts()
     for await (const part of parts) {
       if (part.file) {
         await pump(part.file, fs.createWriteStream(part.filename))

--- a/test/multipart.test.js
+++ b/test/multipart.test.js
@@ -88,7 +88,7 @@ test('should respond when all files are processed', function (t) {
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    const parts = await req.files()
+    const parts = req.files()
     for await (const part of parts) {
       t.ok(part.file)
       await sendToWormhole(part.file)
@@ -137,7 +137,7 @@ test('should group parts with the same name to an array', function (t) {
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    const parts = await req.parts()
+    const parts = req.parts()
     for await (const part of parts) {
       t.ok(part)
       if (Array.isArray(part.fields.upload)) {
@@ -283,7 +283,7 @@ test('should throw error due to filesLimit (The max number of file fields (Defau
 
   fastify.post('/', async function (req, reply) {
     try {
-      const parts = await req.files({ limits: { files: 1 } })
+      const parts = req.files({ limits: { files: 1 } })
       for await (const part of parts) {
         t.ok(part.file)
         await sendToWormhole(part.file)
@@ -335,7 +335,7 @@ test('should be able to configure limits globally with plugin register options',
 
   fastify.post('/', async function (req, reply) {
     try {
-      const parts = await req.files()
+      const parts = req.files()
       for await (const part of parts) {
         t.ok(part.file)
         await sendToWormhole(part.file)
@@ -487,7 +487,7 @@ test('should throw error due to file size limit exceed (Default: true)', functio
 
   fastify.post('/', async function (req, reply) {
     try {
-      const parts = await req.files()
+      const parts = req.files()
       for await (const part of parts) {
         t.ok(part.file)
         await sendToWormhole(part.file)
@@ -537,7 +537,7 @@ test('should not throw error due to file size limit exceed - files setting (Defa
   fastify.register(multipart, { throwFileSizeLimit: false })
 
   fastify.post('/', async function (req, reply) {
-    const parts = await req.files({ limits: { fileSize: 1 } })
+    const parts = req.files({ limits: { fileSize: 1 } })
     for await (const part of parts) {
       t.ok(part.file)
       await sendToWormhole(part.file)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This pull request remove unnecessary await keyword from documentations.

Related: https://github.com/fastify/fastify-multipart/pull/233#issuecomment-841374036, https://github.com/fastify/fastify-multipart/pull/233#issuecomment-841638187

#### Strings to check

- [x] `await req.files`
- [x] `await req.parts`
- [x] `await req.body.`