### PR TITLE
ci: add Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/index.js
+++ b/index.js
@@ -443,7 +443,6 @@ function fastifyMultipart (fastify, options, done) {
 
     function cleanup () {
       request.unpipe(bb)
-      bb.removeAllListeners()
     }
 
     return parts


### PR DESCRIPTION
Closes #232 

The code change required to support Node 16 is one that took a while to figure out. 

These are the symptoms:

- a file sent in the request is larger than the default write stream highWaterMark (16k)
- the user is saving the file to the file system with the decorator `req.saveRequestFiles()`
- the plugin hangs in the async iterators used to loop through the files using a producer/consumer pattern

The reason for this is that the Busboy `finish` event is not emitted, which is breaking the producer/consumer pattern implemented in the plugin.

After much experimentation I traced back the root cause to the `cleanup` function of the plugin which unsubscribes from all Busboy events. My speculation is that something has changed in Node 16 streams which causes such cleanup function, which the plugin calls in 3 cases:

- request `close` event
- Busboy `close` event
- indirectly in Busboy `end` (which, btw, doesn't even seem to exist), `finish` and `error` events

to be called before the Busboy emits its `finish` event, which is what allows the plugin to continue execution.

This seems to also have to to with the file system write stream high watermark (which defaults to 16k), the stream the plugin creates to write received files to the file system when `saveRequestFiles` is called, because setting an arbitrary high value fixes the issue without any other changes. Clearly this is not a solution as we can't just guess how big user files will be.

Hence, removing `busboy.removeAllListeners()` in the plugin's `cleanup` function seems to do the trick and I'm not even sure why it was necessary in the first place, as all tests pass now. 

Because `cleanup` is called in several possible cases, this fix is a sort of hammer because a more refined solution which conditionally skips `busboy.removeAllListener()` may exist too, but this is as much time I could spend on this.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
