### PR TITLE
Fix file stream type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export type Multipart<T = true> = T extends true ? MultipartFile : MultipartValu
 
 export interface MultipartFile {
   toBuffer: () => Promise<Buffer>,
-  file: NodeJS.ReadableStream,
+  file: Readable,
   filepath: string,
   fieldname: string,
   filename: string,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -72,7 +72,7 @@ const runServer = async () => {
     expectError(req.body.foo.file);
     expectType<string>(req.body.foo.value);
 
-    expectType<NodeJS.ReadableStream>(req.body.file.file)
+    expectType<Readable>(req.body.file.file)
     expectError(req.body.file.value);
     reply.send();
   })
@@ -82,7 +82,7 @@ const runServer = async () => {
     reply.send();
 
     // file is a file
-    expectType<NodeJS.ReadableStream>(req.body.file.file)
+    expectType<Readable>(req.body.file.file)
     expectError(req.body.file.value);
   })
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -2,7 +2,7 @@ import fastify from 'fastify'
 import fastifyMultipart from '..'
 import { Multipart, MultipartFields, MultipartFile } from '..'
 import * as util from 'util'
-import { pipeline } from 'stream'
+import { pipeline, Readable } from 'stream'
 import * as fs from 'fs'
 import { expectError, expectType } from 'tsd'
 import { FastifyErrorConstructor } from "fastify-error"
@@ -55,7 +55,7 @@ const runServer = async () => {
   app.post('/', async (req, reply) => {
     const data = await req.file()
 
-    expectType<NodeJS.ReadableStream>(data.file)
+    expectType<Readable>(data.file)
     expectType<MultipartFields>(data.fields)
     expectType<string>(data.fieldname)
     expectType<string>(data.filename)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


fixes #247

Current type is based on incorrect busBoy typings which will be addressed separately. In reality `Readable` is actually provided.