### PR TITLE
fix: remove multipartIterator from types and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ try {
 
 ``` 
 
-Additionally, you can pass per-request options to the  `req.file`, `req.files`, `req.saveRequestFiles` or `req.multipartIterator` function.
+Additionally, you can pass per-request options to the  `req.file`, `req.files`, `req.saveRequestFiles` or `req.parts` function.
 
 ```js
 fastify.post('/', async function (req, reply) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,13 +53,11 @@ declare module "fastify" {
     interface FastifyRequest {
         isMultipart: () => boolean;
 
+        // promise api
         parts: (options?: busboy.BusboyConfig) =>  AsyncIterableIterator<Multipart>
 
         // legacy
         multipart: (handler: MultipartHandler, next: (err: Error) => void, options?: busboy.BusboyConfig) => busboy.Busboy;
-
-        // promise api
-        multipartIterator: (options?: busboy.BusboyConfig) => AsyncIterableIterator<Multipart>
 
         // Stream mode
         file: (options?: busboy.BusboyConfig) => Promise<Multipart>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

This method was removed in https://github.com/fastify/fastify-multipart/pull/147 but is still mentioned in docs and (which is more of a problem) in types.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
