### PR TITLE
Migrate to @fastify/busboy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import * as busboy from "busboy";
+import { Busboy, BusboyConfig } from "@fastify/busboy";
 import { FastifyPluginCallback } from "fastify";
 import { Readable } from 'stream';
 import { FastifyErrorConstructor } from "fastify-error";
@@ -54,17 +54,17 @@ declare module "fastify" {
         isMultipart: () => boolean;
 
         // promise api
-        parts: (options?: busboy.BusboyConfig) =>  AsyncIterableIterator<Multipart>
+        parts: (options?: BusboyConfig) =>  AsyncIterableIterator<Multipart>
 
         // legacy
-        multipart: (handler: MultipartHandler, next: (err: Error) => void, options?: busboy.BusboyConfig) => busboy.Busboy;
+        multipart: (handler: MultipartHandler, next: (err: Error) => void, options?: BusboyConfig) => Busboy;
 
         // Stream mode
-        file: (options?: busboy.BusboyConfig) => Promise<Multipart>
-        files: (options?: busboy.BusboyConfig) => AsyncIterableIterator<Multipart>
+        file: (options?: BusboyConfig) => Promise<Multipart>
+        files: (options?: BusboyConfig) => AsyncIterableIterator<Multipart>
 
         // Disk mode
-        saveRequestFiles: (options?: busboy.BusboyConfig & { tmpdir?: string }) => Promise<Array<Multipart>>
+        saveRequestFiles: (options?: BusboyConfig & { tmpdir?: string }) => Promise<Array<Multipart>>
         cleanRequestFiles: () => Promise<void>
         tmpUploads: Array<Multipart>
     }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Busboy = require('busboy')
+const Busboy = require('@fastify/busboy')
 const os = require('os')
 const fp = require('fastify-plugin')
 const eos = require('end-of-stream')

--- a/index.js
+++ b/index.js
@@ -348,11 +348,6 @@ function fastifyMultipart (fastify, options, done) {
       onError(new FieldsLimitError())
     })
 
-    // TODO: Won't need after https://github.com/mscdex/busboy/pull/237/files
-    if (bb._writableState.autoDestroy) {
-      bb._writableState.autoDestroy = false
-    }
-
     request.pipe(bb)
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated, encoding, contentType) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "@fastify/busboy": "^1.0.0-next2",
+    "@fastify/busboy": "^1.0.0",
     "deepmerge": "^4.2.2",
     "end-of-stream": "^1.4.4",
     "fastify-error": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "types": "index.d.ts",
   "dependencies": {
-    "busboy": "^0.3.1",
+    "@fastify/busboy": "^1.0.0-next2",
     "deepmerge": "^4.2.2",
     "end-of-stream": "^1.4.4",
     "fastify-error": "^0.3.0",
@@ -15,9 +15,8 @@
     "stream-wormhole": "^1.1.0"
   },
   "devDependencies": {
-    "@types/busboy": "^0.2.3",
-    "@types/node": "^16.0.0",
-    "@typescript-eslint/parser": "^4.0.0",
+    "@types/node": "^16.11.11",
+    "@typescript-eslint/parser": "^4.33.0",
     "climem": "^1.0.3",
     "eslint": "^7.7.0",
     "eslint-config-standard": "^16.0.0",
@@ -26,7 +25,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-typescript": "^0.14.0",
-    "fastify": "^3.2.1",
+    "fastify": "^3.24.1",
     "form-data": "^4.0.0",
     "h2url": "^0.2.0",
     "pre-commit": "^1.2.2",
@@ -36,7 +35,7 @@
     "standard": "^16.0.1",
     "tap": "^15.0.1",
     "tsd": "^0.19.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.5.2"
   },
   "scripts": {
     "coverage": "tap \"test/**/*.test.js\" --coverage-report=html",

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -6,6 +6,7 @@ import { pipeline, Readable } from 'stream'
 import * as fs from 'fs'
 import { expectError, expectType } from 'tsd'
 import { FastifyErrorConstructor } from "fastify-error"
+import { BusboyConfig } from "@fastify/busboy";
 
 const pump = util.promisify(pipeline)
 
@@ -45,6 +46,7 @@ const runServer = async () => {
     }, (err) => {
       throw err
     }, {
+      headers: { 'content-type': 'multipart/form-data' },
       limits: {
         fileSize: 10000
       }
@@ -88,7 +90,7 @@ const runServer = async () => {
 
   // busboy
   app.post('/', async function (req, reply) {
-    const options: busboy.BusboyConfig = { limits: { fileSize: 1000 } };
+    const options: BusboyConfig = { headers: { 'content-type': 'multipart/form-data' }, limits: { fileSize: 1000 } };
     const data = await req.file(options)
     await pump(data.file, fs.createWriteStream(data.filename))
     reply.send()
@@ -140,7 +142,7 @@ const runServer = async () => {
 
   // upload files to disk with busboy options
   app.post('/upload/files', async function (req, reply) {
-    const options: busboy.BusboyConfig = { limits: { fileSize: 1000 } };
+    const options: BusboyConfig = { headers: { 'content-type': 'multipart/form-data' }, limits: { fileSize: 1000 } };
     await req.saveRequestFiles(options)
 
     reply.send()


### PR DESCRIPTION
This replaces unsupported original version of `busboy` with our own fork, sporting the holy trifecta of security fixes, performance improvements, and a richer feature-set.
It is a semver minor change with no known breaking changes.

fixes #297

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
