### PR TITLE
Change `MultipartFile#file` type to `BusboyFileStream`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Busboy, BusboyConfig } from "@fastify/busboy";
+import { Busboy, BusboyConfig, BusboyFileStream } from "@fastify/busboy";
 import { FastifyPluginCallback } from "fastify";
 import { Readable } from 'stream';
 import { FastifyErrorConstructor } from "fastify-error";
@@ -27,7 +27,7 @@ export type Multipart<T = true> = T extends true ? MultipartFile : MultipartValu
 
 export interface MultipartFile {
   toBuffer: () => Promise<Buffer>,
-  file: Readable,
+  file: BusboyFileStream,
   filepath: string,
   fieldname: string,
   filename: string,

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -6,7 +6,7 @@ import { pipeline, Readable } from 'stream'
 import * as fs from 'fs'
 import { expectError, expectType } from 'tsd'
 import { FastifyErrorConstructor } from "fastify-error"
-import { BusboyConfig } from "@fastify/busboy";
+import { BusboyConfig, BusboyFileStream } from "@fastify/busboy";
 
 const pump = util.promisify(pipeline)
 
@@ -56,7 +56,8 @@ const runServer = async () => {
   app.post('/', async (req, reply) => {
     const data = await req.file()
 
-    expectType<Readable>(data.file)
+    expectType<BusboyFileStream>(data.file)
+    expectType<boolean>(data.file.truncated)
     expectType<MultipartFields>(data.fields)
     expectType<string>(data.fieldname)
     expectType<string>(data.filename)
@@ -73,7 +74,7 @@ const runServer = async () => {
     expectError(req.body.foo.file);
     expectType<string>(req.body.foo.value);
 
-    expectType<Readable>(req.body.file.file)
+    expectType<BusboyFileStream>(req.body.file.file)
     expectError(req.body.file.value);
     reply.send();
   })
@@ -83,7 +84,7 @@ const runServer = async () => {
     reply.send();
 
     // file is a file
-    expectType<Readable>(req.body.file.file)
+    expectType<BusboyFileStream>(req.body.file.file)
     expectError(req.body.file.value);
   })
 


### PR DESCRIPTION
By changing the type of `MultipartFile#file` to `BusboyFileStream`, accessing the `truncated` property no longer raises a TypeScript error.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
