### PR TITLE
feat: added destroying of part.file if the node request ends with an error event

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fastify": "^3.24.1",
     "form-data": "^4.0.0",
     "h2url": "^0.2.0",
+    "noop-stream": "^0.1.0",
     "pre-commit": "^1.2.2",
     "pump": "^3.0.0",
     "readable-stream": "^3.6.0",

--- a/test/multipart-incomplete-upload.test.js
+++ b/test/multipart-incomplete-upload.test.js
@@ -1,0 +1,62 @@
+'use strict'
+
+const util = require('util')
+const test = require('tap').test
+const FormData = require('form-data')
+const Fastify = require('fastify')
+const multipart = require('..')
+const http = require('http')
+const sleep = util.promisify(setTimeout)
+const { writableNoopStream } = require('noop-stream')
+const stream = require('stream')
+const pipeline = util.promisify(stream.pipeline)
+
+test('should finish with error on partial upload', async function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req) {
+    t.ok(req.isMultipart())
+    const parts = await req.files()
+    try {
+      for await (const part of parts) {
+        await pipeline(part.file, writableNoopStream())
+      }
+    } catch (e) {
+      t.equal(e.message, 'Premature close', 'File was closed prematurely')
+      throw e
+    } finally {
+      t.pass('Finished request')
+    }
+    return 'ok'
+  })
+
+  await fastify.listen(0)
+  const dataSize = 1024 * 6
+  // request
+  const form = new FormData()
+  form.append('upload', Buffer.alloc(dataSize))
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  req.on('error', () => {
+    t.pass('ended http request with error')
+  })
+  const data = form.getBuffer()
+  req.write(data.slice(0, dataSize / 2))
+  await sleep(100)
+  req.destroy()
+  await sleep(100)
+  t.end()
+})


### PR DESCRIPTION
If the client cancels the http request (e.g. just closes the socket),
the underlying file stream will not be closed with an error but
the request handling will hang.

The tests saves the stream of a file part into a Noop write stream
through pipeline. If the client cancels the request, the pipeline
call will not return. With the fix, we keep track of the file that
is currently being processed and in the case of an error event on the
node request, this file will be destroyed.

This addresses #315 and makes https://github.com/fastify/busboy/pull/81 superflous.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
