### PR TITLE
Option to attach to body as key-value pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,17 @@ fastify.post('/upload/files', async function (req, reply) {
 })
 ```
 
+Request body key-value pairs can be assigned directly using `attachFieldsToBody: 'keyValues'`. Field values will be attached directly to the body object. By default, all files are converted to a string using `buffer.toString()` used as the value attached to the body.
+
+```js
+fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues' })
+
+fastify.post('/upload/files', async function (req, reply) {
+  const uploadValue = req.body.upload // access file as string
+  const fooValue = req.body.foo       // other fields
+})
+```
+
 You can also define an `onFile` handler to avoid accumulating all files in memory.
 
 ```js
@@ -250,13 +261,60 @@ fastify.post('/upload/files', async function (req, reply) {
 })
 ```
 
+The `onFile` handler can also be used with `attachFieldsToBody: 'keyValues'` in order to specify how file buffer values are decoded.
+
+```js
+async function onFile(part) {
+  const buff = await part.toBuffer()
+  const decoded = Buffer.from(buff.toString(), 'base64').toString()
+  part.value = decoded // set `part.value` to specify the request body value
+}
+
+fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues', onFile })
+
+fastify.post('/upload/files', async function (req, reply) {
+  const uploadValue = req.body.upload // access file as base64 string
+  const fooValue = req.body.foo       // other fields
+})
+```
+
 **Note**: if you assign all fields to the body and don't define an `onFile` handler, you won't be able to read the files through streams, as they are already read and their contents are accumulated in memory.
 You can only use the `toBuffer` method to read the content.
 If you try to read from a stream and pipe to a new file, you will obtain an empty new file.
 
 ## JSON Schema body validation
 
-If you enable `attachFieldsToBody` and set `sharedSchemaId` a shared JSON Schema is added, which can be used to validate parsed multipart fields.
+If you enable `attachFieldsToBody: 'keyValues'` then the response body and JSON Schema validation will behave the similary to `application/json` and [`application/x-www-form-urlencoded`](https://github.com/fastify/fastify-formbody) content types. Files will be decoded using `Buffer.toString()` and attached as a body value.
+
+```js
+fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues' })
+
+fastify.post('/upload/files', {
+  schema: {
+    body: {
+      type: 'object',
+      required: ['myFile'],
+      properties: {
+        // file that gets decoded to string
+        myFile: {
+          type: 'string',
+          // match a UUID
+          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        },
+        hello: {
+          type: 'string',
+          enum: ['world']
+        }
+      }
+    }
+  }
+}, function (req, reply) {
+  console.log({ body: req.body })
+  reply.send('done')
+})
+```
+
+If you enable `attachFieldsToBody: true` and set `sharedSchemaId` a shared JSON Schema is added, which can be used to validate parsed multipart fields.
 
 ```js
 const opts = {

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ If you try to read from a stream and pipe to a new file, you will obtain an empt
 
 ## JSON Schema body validation
 
-If you enable `attachFieldsToBody: 'keyValues'` then the response body and JSON Schema validation will behave the similary to `application/json` and [`application/x-www-form-urlencoded`](https://github.com/fastify/fastify-formbody) content types. Files will be decoded using `Buffer.toString()` and attached as a body value.
+If you enable `attachFieldsToBody: 'keyValues'` then the response body and JSON Schema validation will behave similarly to `application/json` and [`application/x-www-form-urlencoded`](https://github.com/fastify/fastify-formbody) content types. Files will be decoded using `Buffer.toString()` and attached as a body value.
 
 ```js
 fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues' })

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ fastify.post('/upload/files', {
         // file that gets decoded to string
         myFile: {
           type: 'string',
-          // match a UUID
+          // validate that file contents match a UUID
           pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
         },
         hello: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,7 +150,7 @@ export interface FastifyMultipartAttactFieldsToBodyOptions extends FastifyMultip
     /**
      * Only valid in the promise api. Append the multipart parameters to the body object.
      */
-    attachFieldsToBody: true
+    attachFieldsToBody: true | 'valueOnly';
 
     /**
      * Manage the file stream like you need

--- a/index.d.ts
+++ b/index.d.ts
@@ -150,7 +150,7 @@ export interface FastifyMultipartAttactFieldsToBodyOptions extends FastifyMultip
     /**
      * Only valid in the promise api. Append the multipart parameters to the body object.
      */
-    attachFieldsToBody: true | 'valueOnly';
+    attachFieldsToBody: true | 'keyValues';
 
     /**
      * Manage the file stream like you need

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function fastifyMultipart (fastify, options, done) {
     })
   }
 
-  if (options.attachFieldsToBody === true) {
+  if (options.attachFieldsToBody === true || options.attachFieldsToBody === 'valueOnly') {
     if (typeof options.sharedSchemaId === 'string') {
       fastify.addSchema({
         $id: options.sharedSchemaId,
@@ -146,6 +146,17 @@ function fastifyMultipart (fastify, options, done) {
             await part.toBuffer()
           }
         }
+      }
+      if (options.attachFieldsToBody === 'valueOnly') {
+        const body = {}
+        for (const [key, field] of Object.entries(req.body)) {
+          if (field.value !== undefined) {
+            body[key] = field.value
+          } else if (field._buf !== undefined) {
+            body[key] = field._buf.toString()
+          }
+        }
+        req.body = body
       }
     })
   }

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ function fastifyMultipart (fastify, options, done) {
     })
   }
 
-  if (options.attachFieldsToBody === true || options.attachFieldsToBody === 'valueOnly') {
+  if (options.attachFieldsToBody === true || options.attachFieldsToBody === 'keyValues') {
     if (typeof options.sharedSchemaId === 'string') {
       fastify.addSchema({
         $id: options.sharedSchemaId,
@@ -147,7 +147,7 @@ function fastifyMultipart (fastify, options, done) {
           }
         }
       }
-      if (options.attachFieldsToBody === 'valueOnly') {
+      if (options.attachFieldsToBody === 'keyValues') {
         const body = {}
         for (const [key, field] of Object.entries(req.body)) {
           if (field.value !== undefined) {

--- a/index.js
+++ b/index.js
@@ -149,7 +149,8 @@ function fastifyMultipart (fastify, options, done) {
       }
       if (options.attachFieldsToBody === 'keyValues') {
         const body = {}
-        for (const [key, field] of Object.entries(req.body)) {
+        for (const key of Object.keys(req.body)) {
+          const field = req.body[key]
           if (field.value !== undefined) {
             body[key] = field.value
           } else if (field._buf !== undefined) {

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -8,6 +8,7 @@ const http = require('http')
 const path = require('path')
 const fs = require('fs')
 const { once } = require('events')
+const { Readable } = require('stream')
 
 const filePath = path.join(__dirname, '../README.md')
 
@@ -49,6 +50,105 @@ test('should be able to attach all parsed fields and files and make it accessibl
 
   const req = http.request(opts)
   form.append('upload', fs.createReadStream(filePath))
+  form.append('hello', 'world')
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})
+
+test('should be able to attach all parsed field values and files and make it accessible through "req.body"', async function (t) {
+  t.plan(6)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: 'valueOnly' })
+
+  const original = fs.readFileSync(filePath, 'utf8')
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload', 'hello'])
+
+    t.equal(req.body.upload, original)
+    t.equal(req.body.hello, 'world')
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+  form.append('hello', 'world')
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})
+
+test('should be able to attach all parsed field values and files with custom "onFile" handler and make it accessible through "req.body"', async function (t) {
+  t.plan(7)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  async function onFile (part) {
+    t.pass('custom onFile handler')
+    const buff = await part.toBuffer()
+    const decoded = Buffer.from(buff.toString(), 'base64').toString()
+    part.value = decoded
+  }
+
+  fastify.register(multipart, { attachFieldsToBody: 'valueOnly', onFile })
+
+  const original = 'test upload content'
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload', 'hello'])
+
+    t.equal(req.body.upload, original)
+    t.equal(req.body.hello, 'world')
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', Readable.from(Buffer.from(original).toString('base64')))
   form.append('hello', 'world')
   form.pipe(req)
 

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -66,7 +66,7 @@ test('should be able to attach all parsed field values and files and make it acc
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
 
-  fastify.register(multipart, { attachFieldsToBody: 'valueOnly' })
+  fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   const original = fs.readFileSync(filePath, 'utf8')
 
@@ -119,7 +119,7 @@ test('should be able to attach all parsed field values and files with custom "on
     part.value = decoded
   }
 
-  fastify.register(multipart, { attachFieldsToBody: 'valueOnly', onFile })
+  fastify.register(multipart, { attachFieldsToBody: 'keyValues', onFile })
 
   const original = 'test upload content'
 

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -60,6 +60,52 @@ test('should be able to attach all parsed fields and files and make it accessibl
   t.pass('res ended successfully')
 })
 
+test('should be able to attach all parsed field values and json content files and make it accessible through "req.body"', async function (t) {
+  t.plan(6)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
+
+  const original = { testContent: 'test upload content' }
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload', 'hello'])
+
+    t.same(req.body.upload, original)
+    t.equal(req.body.hello, 'world')
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', Readable.from(Buffer.from(JSON.stringify(original))), { contentType: 'application/json' })
+  form.append('hello', 'world')
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})
+
 test('should be able to attach all parsed field values and files and make it accessible through "req.body"', async function (t) {
   t.plan(6)
 


### PR DESCRIPTION
Adds an option `attachFieldsToBody: 'valueOnly'`. When this is option is enabled, the field values are attached to the body directly, similar to what is described in the readme:
```js
  const body = Object.fromEntries(
    Object.keys(req.body).map((key) => [key, req.body[key].value])
  ) // Request body in key-value pairs, like req.body in Express
```

This would be a convenient feature to include so that json-schemas can be shared more easily between the content types `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data`. 

Without this capability, this needs to be performed in awkward route handler transforms, e.g.:
```ts
fastify.post<{ Body: ServiceAuthRequest, Reply: ServiceAuthResponse }>('/request_key', {
  preValidation: (request, _reply, done) => {
    if (request.isMultipart()) {
      // 🤢
      const body = request.body as unknown as Record<string, { value: string } | { _buf: Buffer }>;
      for (let [k, v] of Object.entries(body)) {
        const value = 'value' in v ? v.value : v._buf.toString();
        (request.body as any)[k] = value;
      }
    }
    done();
  },
  schema: {
    body: ServiceAuthRequestSchema,
    headers: ServiceAuthRequestHeadersSchema,
    response: {
      200: ServiceAuthResponseSchema,
    }
  },
}, 
async (request, reply) => {
  ...
});
```

---

Please let me know if the the convention `attachFieldsToBody: 'valueOnly'` should be changed to something else.

Also, currently files are converted to a string via `.toBuffer().toString()`. It's possible to use the `onFile` handler to customize the file buffer decoding, which is performed in one of the new tests.

Let me know if this feature make sense, and I'm happy to add info to the docs/readme.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
