### PR TITLE
chore: fix typo octect -> octet

### DIFF
--- a/test/big.test.js
+++ b/test/big.test.js
@@ -30,7 +30,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
         t.equal(part.fieldname, 'upload')
         t.equal(part.filename, 'random-data')
         t.equal(part.encoding, '7bit')
-        t.equal(part.mimetype, 'binary/octect-stream')
+        t.equal(part.mimetype, 'binary/octet-stream')
 
         await sendToWormhole(part.file)
       }
@@ -68,7 +68,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
     })
     form.append('upload', rs, {
       filename: 'random-data',
-      contentType: 'binary/octect-stream',
+      contentType: 'binary/octet-stream',
       knownLength
     })
 

--- a/test/legacy/big.test.js
+++ b/test/legacy/big.test.js
@@ -35,7 +35,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
       t.equal(filename, 'random-data')
       t.equal(field, 'upload')
       t.equal(encoding, '7bit')
-      t.equal(mimetype, 'binary/octect-stream')
+      t.equal(mimetype, 'binary/octet-stream')
       const hashOutput = crypto.createHash('sha256')
 
       pump(file, hashOutput, new Writable({
@@ -88,7 +88,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
     })
     form.append('upload', rs, {
       filename: 'random-data',
-      contentType: 'binary/octect-stream',
+      contentType: 'binary/octet-stream',
       knownLength
     })
 

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -69,7 +69,7 @@ test('should emit fileSize limitation error during streaming', async function (t
   const req = http.request(opts)
   form.append('upload', rs, {
     filename: 'random-data',
-    contentType: 'binary/octect-stream',
+    contentType: 'binary/octet-stream',
     knownLength
   })
 

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -340,7 +340,7 @@ test('should throw on file limit error, after highWaterMark', async function (t)
   const req = http.request(opts)
   form.append('upload2', rs, {
     filename: 'random-data',
-    contentType: 'binary/octect-stream',
+    contentType: 'binary/octet-stream',
     knownLength
   })
 
@@ -454,7 +454,7 @@ test('should process large files correctly', async function (t) {
 
   form.append('upload', rs, {
     filename: 'random-data',
-    contentType: 'binary/octect-stream',
+    contentType: 'binary/octet-stream',
     knownLength
   })
 

--- a/tester.js
+++ b/tester.js
@@ -31,7 +31,7 @@ function next () {
   form.append('my_field', 'my value')
   form.append('upload', rs, {
     filename: 'random-data',
-    contentType: 'binary/octect-stream',
+    contentType: 'binary/octet-stream',
     knownLength
   })
 


### PR DESCRIPTION
This PR fixes a typo.
`octect` -> `octet`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
