### PR TITLE
Create key values when multiple files are uploaded

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,10 +156,10 @@ function fastifyMultipart (fastify, options, done) {
           } else if (Array.isArray(field)) {
             body[key] = []
             for (const arrayField of field) {
-               if (field.value !== undefined) {
-                 body[key].push(arrayField.value)
-               }
-            }  
+              if (field.value !== undefined) {
+                body[key].push(arrayField.value)
+              }
+            }
           } else if (field._buf !== undefined) {
             body[key] = field._buf.toString()
           }

--- a/index.js
+++ b/index.js
@@ -153,6 +153,13 @@ function fastifyMultipart (fastify, options, done) {
           const field = req.body[key]
           if (field.value !== undefined) {
             body[key] = field.value
+          } else if (Array.isArray(field)) {
+            body[key] = []
+            for (const arrayField of field) {
+               if (field.value !== undefined) {
+                 body[key].push(arrayField.value)
+               }
+            }  
           } else if (field._buf !== undefined) {
             body[key] = field._buf.toString()
           }


### PR DESCRIPTION
When you define sharedSchemaId and you want to allow multiple files upload, the files are in array and no value can be returned from onFile in this case.