### PR TITLE
fix: manage big file uploads

### DIFF
--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const crypto = require('crypto')
 const test = require('tap').test
 const FormData = require('form-data')
@@ -49,7 +50,7 @@ test('should throw fileSize limitation error when consuming the stream', async f
     method: 'POST'
   }
 
-  const randomFileBuffer = Buffer.alloc(600000)
+  const randomFileBuffer = Buffer.alloc(600_000)
   crypto.randomFillSync(randomFileBuffer)
 
   const req = http.request(opts)
@@ -62,6 +63,69 @@ test('should throw fileSize limitation error when consuming the stream', async f
     t.equal(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
+  } catch (error) {
+    t.error(error, 'request')
+  }
+})
+
+test('should throw fileSize limitation error when consuming the stream MBs', async function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, {
+    throwFileSizeLimit: true,
+    limits: {
+      fileSize: 5_000_000 // 5MB
+    }
+  })
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    const part = await req.file()
+    t.pass('the file is not consumed yet')
+
+    try {
+      await part.toBuffer()
+      t.fail('it should throw')
+    } catch (error) {
+      t.ok(error)
+      reply.send(error)
+    }
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    hostname: '127.0.0.1',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const randomFileBuffer = Buffer.alloc(15_000_000)
+  crypto.randomFillSync(randomFileBuffer)
+
+  const tmpFile = 'test/random-file'
+  fs.writeFileSync(tmpFile, randomFileBuffer)
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(tmpFile))
+
+  form.pipe(req)
+
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 413)
+    res.resume()
+    await once(res, 'end')
+
+    fs.unlinkSync(tmpFile)
   } catch (error) {
     t.error(error, 'request')
   }


### PR DESCRIPTION
closes #383

increase coverage #202:

```
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |    96.85 |     100 |     100 |                   
 index.js |     100 |    96.85 |     100 |     100 | 163,247-254,551   
----------|---------|----------|---------|---------|-------------------
```

benefit #378:
from https://nodejs.org/api/stream.html#readablesymbolasynciterator

> If the loop terminates with a break, return, or a throw, the stream will be destroyed

