### PR TITLE
Always include form value's content-type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ export interface SavedMultipartFile extends MultipartFile {
 export interface MultipartValue<T = unknown> {
   value: T;
   fieldname: string;
-  mimetype?: string;
+  mimetype: string;
   encoding: string;
   fieldnameTruncated: boolean;
   valueTruncated: boolean;

--- a/index.js
+++ b/index.js
@@ -372,8 +372,6 @@ function fastifyMultipart (fastify, options, done) {
     request.pipe(bb)
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated, encoding, contentType) {
-      let mimetype
-
       // don't overwrite prototypes
       if (getDescriptor(Object.prototype, name)) {
         onError(new PrototypeViolationError())
@@ -390,7 +388,6 @@ function fastifyMultipart (fastify, options, done) {
 
         try {
           fieldValue = secureJSON.parse(fieldValue)
-          mimetype = 'application/json'
         } catch (e) {
           onError(new InvalidJSONFieldError())
           return
@@ -399,7 +396,7 @@ function fastifyMultipart (fastify, options, done) {
 
       const value = {
         fieldname: name,
-        mimetype,
+        mimetype: contentType,
         encoding,
         value: fieldValue,
         fieldnameTruncated,

--- a/index.js
+++ b/index.js
@@ -388,6 +388,7 @@ function fastifyMultipart (fastify, options, done) {
 
         try {
           fieldValue = secureJSON.parse(fieldValue)
+          contentType = 'application/json'
         } catch (e) {
           onError(new InvalidJSONFieldError())
           return


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Include the content-type even if it's not JSON.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
