### PR TITLE
fix: package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/multipart",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Multipart plugin for Fastify",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
cc @mcollina - give the latest version of `npm i releasify -g` a shot. It is ugly but it works like a charm

Now it supports the github release body message by executing the command:

```
releasify publish -n -s minor --gh-release-body
```
