### PR TITLE
fix: empty bodies does not crash anymore

### DIFF
--- a/index.js
+++ b/index.js
@@ -524,6 +524,10 @@ function fastifyMultipart (fastify, options, done) {
   async function saveRequestFiles (options) {
     let files
     if (attachFieldsToBody === true) {
+      // Skip the whole process if the body is empty
+      if (!this.body) {
+        return []
+      }
       files = filesFromFields.call(this, this.body)
     } else {
       files = await this.files(options)

--- a/test/multipart-empty-body.test.js
+++ b/test/multipart-empty-body.test.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const test = require('tap').test
+const FormData = require('form-data')
+const Fastify = require('fastify')
+const multipart = require('..')
+const http = require('http')
+const { once } = require('events')
+
+test('should not break with a empty request body when attachFieldsToBody is true', async function (t) {
+  t.plan(5)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: true })
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    const files = await req.saveRequestFiles()
+
+    t.ok(Array.isArray(files))
+    t.equal(files.length, 0)
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})


### PR DESCRIPTION
Closes #417 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
