### PR TITLE
feat: part.type for easy type narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,10 @@ fastify.post('/', async function (req, reply) {
 fastify.post('/upload/raw/any', async function (req, reply) {
   const parts = req.parts()
   for await (const part of parts) {
-    if (part.file) {
+    if (part.type === 'file') {
       await pump(part.file, fs.createWriteStream(part.filename))
     } else {
+      // part.type === 'field
       console.log(part)
     }
   }
@@ -177,6 +178,7 @@ This will store all files in the operating system default directory for temporar
 fastify.post('/upload/files', async function (req, reply) {
   // stores files to tmp dir and return files
   const files = await req.saveRequestFiles()
+  files[0].type // "file"
   files[0].filepath
   files[0].fieldname
   files[0].filename

--- a/examples/example.js
+++ b/examples/example.js
@@ -41,9 +41,10 @@ fastify.post('/upload/stream/files', async function (req, reply) {
 fastify.post('/upload/raw/any', async function (req, reply) {
   const parts = req.parts()
   for await (const part of parts) {
-    if (part.file) {
+    if (part.type === 'file') {
       await pump(part.file, fs.createWriteStream(part.filename))
     } else {
+      // part.type === 'field'
       console.log(part)
     }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,6 +82,7 @@ declare namespace fastifyMultipart {
   export type Multipart = MultipartFile | MultipartValue;
 
   export interface MultipartFile {
+    type: 'file';
     toBuffer: () => Promise<Buffer>;
     file: BusboyFileStream;
     fieldname: string;
@@ -92,6 +93,7 @@ declare namespace fastifyMultipart {
   }
 
   export interface MultipartValue<T = unknown> {
+    type: 'field';
     value: T;
     fieldname: string;
     mimetype: string;

--- a/index.js
+++ b/index.js
@@ -410,6 +410,7 @@ function fastifyMultipart (fastify, options, done) {
       }
 
       const value = {
+        type: 'field',
         fieldname: name,
         mimetype: contentType,
         encoding,
@@ -444,6 +445,7 @@ function fastifyMultipart (fastify, options, done) {
         : defaultThrowFileSizeLimit
 
       const value = {
+        type: 'file',
         fieldname: name,
         filename,
         encoding,

--- a/test/big.test.js
+++ b/test/big.test.js
@@ -13,7 +13,7 @@ const sendToWormhole = require('stream-wormhole')
 
 // skipping on Github Actions because it takes too long
 test('should upload a big file in constant memory', { skip: process.env.CI }, function (t) {
-  t.plan(9)
+  t.plan(10)
 
   const fastify = Fastify()
   const hashInput = crypto.createHash('sha256')
@@ -32,6 +32,7 @@ test('should upload a big file in constant memory', { skip: process.env.CI }, fu
 
     for await (const part of req.parts()) {
       if (part.file) {
+        t.equal(part.type, 'file')
         t.equal(part.fieldname, 'upload')
         t.equal(part.filename, 'random-data')
         t.equal(part.encoding, '7bit')

--- a/test/fix-313.test.js
+++ b/test/fix-313.test.js
@@ -14,7 +14,7 @@ const { once } = EventEmitter
 const filePath = path.join(__dirname, '../README.md')
 
 test('should store file on disk, remove on response when attach fields to body is true', async function (t) {
-  t.plan(22)
+  t.plan(25)
 
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -29,18 +29,21 @@ test('should store file on disk, remove on response when attach fields to body i
     const files = await req.saveRequestFiles()
 
     t.ok(files[0].filepath)
+    t.equal(files[0].type, 'file')
     t.equal(files[0].fieldname, 'upload')
     t.equal(files[0].filename, 'README.md')
     t.equal(files[0].encoding, '7bit')
     t.equal(files[0].mimetype, 'text/markdown')
     t.ok(files[0].fields.upload)
     t.ok(files[1].filepath)
+    t.equal(files[1].type, 'file')
     t.equal(files[1].fieldname, 'upload')
     t.equal(files[1].filename, 'README.md')
     t.equal(files[1].encoding, '7bit')
     t.equal(files[1].mimetype, 'text/markdown')
     t.ok(files[1].fields.upload)
     t.ok(files[2].filepath)
+    t.equal(files[2].type, 'file')
     t.equal(files[2].fieldname, 'other')
     t.equal(files[2].filename, 'README.md')
     t.equal(files[2].encoding, '7bit')

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -90,7 +90,7 @@ const runServer = async () => {
     expectType<string>(req.body.foo.value);
 
     expectType<BusboyFileStream>(req.body.file.file)
-    expectAssignable<string>(req.body.file.type);
+    expectType<'file'>(req.body.file.type);
     reply.send();
   })
 

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -56,7 +56,7 @@ const runServer = async () => {
     const data = await req.file()
     if (data == null) throw new Error('missing file')
     
-    expectAssignable<string>(data.type)
+    expectType<'file'>(data.type)
     expectType<BusboyFileStream>(data.file)
     expectType<boolean>(data.file.truncated)
     expectType<MultipartFields>(data.fields)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -86,6 +86,7 @@ const runServer = async () => {
   // Multiple fields including scalar values
   app.post<{Body: {file: MultipartFile, foo: MultipartValue<string>}}>('/upload/stringvalue', async (req, reply) => {
     expectError(req.body.foo.file);
+    expectType<'field'>(req.body.foo.type)
     expectType<string>(req.body.foo.value);
 
     expectType<BusboyFileStream>(req.body.file.file)

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -3,7 +3,7 @@ import fastifyMultipart, {MultipartValue, MultipartFields, MultipartFile } from 
 import * as util from 'util'
 import { pipeline } from 'stream'
 import * as fs from 'fs'
-import { expectError, expectType, expectAssignable } from 'tsd'
+import { expectError, expectType } from 'tsd'
 import { FastifyErrorConstructor } from "@fastify/error"
 import { BusboyConfig, BusboyFileStream } from "@fastify/busboy";
 

--- a/test/multipart-body-schema.test.js
+++ b/test/multipart-body-schema.test.js
@@ -11,7 +11,7 @@ const fs = require('fs')
 const filePath = path.join(__dirname, '../README.md')
 
 test('should be able to use JSON schema to validate request', function (t) {
-  t.plan(6)
+  t.plan(7)
 
   const fastify = Fastify()
   t.teardown(fastify.close.bind(fastify))
@@ -39,6 +39,7 @@ test('should be able to use JSON schema to validate request', function (t) {
     const content = await req.body.upload.toBuffer()
 
     t.equal(content.toString(), original)
+    t.equal(req.body.hello.type, 'field')
     t.equal(req.body.hello.value, 'world')
 
     reply.code(200).send()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Easier type narrowing as discussed #144

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

