### PR TITLE
Bind original request to `onFile` function `this`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ You can also define an `onFile` handler to avoid accumulating all files in memor
 
 ```js
 async function onFile(part) {
+  // you have access to original request via `this`
+  console.log(this.id)
   await pump(part.file, fs.createWriteStream(part.filename))
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Busboy, BusboyConfig, BusboyFileStream } from "@fastify/busboy";
-import { FastifyPluginCallback } from "fastify";
+import { FastifyPluginCallback, FastifyRequest } from "fastify";
 import { Readable } from "stream";
 import { FastifyErrorConstructor } from "@fastify/error";
 
@@ -200,7 +200,7 @@ declare namespace fastifyMultipart {
     /**
      * Manage the file stream like you need
      */
-    onFile?: (part: MultipartFile) => void | Promise<void>;
+    onFile?: (this: boolean, part: MultipartFile) => void | Promise<void>;
   }
 
   export const fastifyMultipart: FastifyMultipartPlugin;

--- a/index.d.ts
+++ b/index.d.ts
@@ -200,7 +200,7 @@ declare namespace fastifyMultipart {
     /**
      * Manage the file stream like you need
      */
-    onFile?: (this: boolean, part: MultipartFile) => void | Promise<void>;
+    onFile?: (this: FastifyRequest, part: MultipartFile) => void | Promise<void>;
   }
 
   export const fastifyMultipart: FastifyMultipartPlugin;

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function fastifyMultipart (fastify, options, done) {
         req.body = part.fields
         if (part.file) {
           if (options.onFile) {
-            await options.onFile.bind(req)(part)
+            await options.onFile.call(req, part)
           } else {
             await part.toBuffer()
           }

--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ function fastifyMultipart (fastify, options, done) {
         req.body = part.fields
         if (part.file) {
           if (options.onFile) {
-            await options.onFile(part)
+            await options.onFile.bind(req)(part)
           } else {
             await part.toBuffer()
           }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Gives access to original request via `this` on `onFile` function. This should be useful to link file handler with original request or create unique IDs based on request id.
Fixes #427 
