### PR TITLE
Include `ajvFilePlugin` into source and follow OpenAPI convention.

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ const fastify = require('fastify')({
  // ...
   ajv: {
     // Adds the file plugin to help @fastify/swagger schema generation
-    plugins: [import('@fastify/multipart').ajvFilePlugin]
+    plugins: [require('@fastify/multipart').ajvFilePlugin]
   }
 })
 

--- a/README.md
+++ b/README.md
@@ -379,28 +379,18 @@ The shared schema, that is added, will look like this:
 If you want to use `@fastify/multipart` with `@fastify/swagger` and `@fastify/swagger-ui` you must add a new type called `isFile` and use custom instance of validator compiler [Docs](https://www.fastify.io/docs/latest/Reference/Validation-and-Serialization/#validator-compiler).
 
 ```js
-
-const ajvFilePlugin = (ajv, options = {}) => {
- return ajv.addKeyword({
-  keyword: "isFile",
-  compile: (_schema, parent, _it) => {
-   parent.type = "file";
-   delete parent.isFile;
-   return () => true;
-  },
- });
-};
+ 
 const fastify = require('fastify')({
  // ...
   ajv: {
-    // add the new ajv plugin
-    plugins: [/*...*/ ajvFilePlugin]
+    // Adds the file plugin to help @fastify/swagger schema generation
+    plugins: [import('@fastify/multipart').ajvFilePlugin]
   }
 })
-const opts = {
+
+fastify.register(require("@fastify/multipart"), {
   attachFieldsToBody: true,
-};
-fastify.register(require(".."), opts);
+});
 
 fastify.post(
   "/upload/files",

--- a/examples/example-with-swagger.js
+++ b/examples/example-with-swagger.js
@@ -1,26 +1,21 @@
 'use strict'
-const ajvFilePlugin = (ajv, options = {}) => {
-  return ajv.addKeyword({
-    keyword: 'isFile',
-    compile: (_schema, parent, _it) => {
-      parent.type = 'file'
-      delete parent.isFile
-      return () => true
-    }
-  })
-}
+
 const fastify = require('fastify')({
+  // ...
   logger: true,
   ajv: {
-    plugins: [ajvFilePlugin]
+    // Adds the file plugin to help @fastify/swagger schema generation
+    plugins: [import('..').ajvFilePlugin]
   }
 })
 
 fastify.register(require('..'), {
   attachFieldsToBody: true
 })
+
 fastify.register(require('fastify-swagger'))
 fastify.register(require('@fastify/swagger-ui'))
+
 fastify.post(
   '/upload/files',
   {

--- a/examples/example-with-swagger.js
+++ b/examples/example-with-swagger.js
@@ -5,7 +5,7 @@ const fastify = require('fastify')({
   logger: true,
   ajv: {
     // Adds the file plugin to help @fastify/swagger schema generation
-    plugins: [import('..').ajvFilePlugin]
+    plugins: [require('..').ajvFilePlugin]
   }
 })
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -203,6 +203,11 @@ declare namespace fastifyMultipart {
     onFile?: (this: FastifyRequest, part: MultipartFile) => void | Promise<void>;
   }
 
+  /**
+   * Adds a new type `isFile` to help @fastify/swagger generate the correct schema.
+   */
+  export function ajvFilePlugin(ajv: any): void;
+
   export const fastifyMultipart: FastifyMultipartPlugin;
   export { fastifyMultipart as default };
 }

--- a/index.js
+++ b/index.js
@@ -627,9 +627,15 @@ function ajvFilePlugin (ajv) {
   return ajv.addKeyword({
     keyword: 'isFile',
     compile: (_schema, parent) => {
-      parent.type = 'file'
+      // Updates the schema to match the file type
+      parent.type = 'string'
+      parent.format = 'binary'
       delete parent.isFile
-      return () => true
+
+      return (field /* MultipartFile */) => !!field.file
+    },
+    error: {
+      message: 'should be a file'
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -621,6 +621,20 @@ function fastifyMultipart (fastify, options, done) {
 }
 
 /**
+ * Adds a new type `isFile` to help @fastify/swagger generate the correct schema.
+ */
+function ajvFilePlugin (ajv) {
+  return ajv.addKeyword({
+    keyword: 'isFile',
+    compile: (_schema, parent) => {
+      parent.type = 'file'
+      delete parent.isFile
+      return () => true
+    }
+  })
+}
+
+/**
  * These export configurations enable JS and TS developers
  * to consumer fastify in whatever way best suits their needs.
  */
@@ -630,3 +644,4 @@ module.exports = fp(fastifyMultipart, {
 })
 module.exports.default = fastifyMultipart
 module.exports.fastifyMultipart = fastifyMultipart
+module.exports.ajvFilePlugin = ajvFilePlugin

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@fastify/busboy": "^1.0.0",
     "@fastify/deepmerge": "^1.0.0",
     "@fastify/error": "^3.0.0",
-    "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^1.8.0",
     "end-of-stream": "^1.4.4",
     "fastify-plugin": "^4.0.0",
@@ -17,6 +16,7 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
+    "@fastify/swagger": "^8.3.1",
     "@types/node": "^20.1.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fastify/busboy": "^1.0.0",
     "@fastify/deepmerge": "^1.0.0",
     "@fastify/error": "^3.0.0",
+    "@fastify/swagger": "^8.3.1",
     "@fastify/swagger-ui": "^1.8.0",
     "end-of-stream": "^1.4.4",
     "fastify-plugin": "^4.0.0",
@@ -16,7 +17,6 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
-    "@fastify/swagger": "^8.3.1",
     "@types/node": "^20.1.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",

--- a/test/avj-plugin.test-d.ts
+++ b/test/avj-plugin.test-d.ts
@@ -1,0 +1,13 @@
+import fastify from 'fastify'
+import { fastifyMultipart, ajvFilePlugin } from '..'
+
+const app = fastify({
+  ajv: {
+    plugins: [
+      ajvFilePlugin,
+      (await import('..')).ajvFilePlugin
+    ]
+  }
+})
+
+app.register(fastifyMultipart)

--- a/test/multipart-ajv-file.test.js
+++ b/test/multipart-ajv-file.test.js
@@ -1,0 +1,70 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const multipart = require('..')
+
+test('show modify the generated schema', async function (t) {
+  t.plan(1)
+
+  const fastify = Fastify({
+    ajv: {
+      plugins: [multipart.ajvFilePlugin]
+    }
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(multipart)
+  await fastify.register(require('@fastify/swagger'), {
+    mode: 'dynamic',
+
+    openapi: {
+      openapi: '3.1.0'
+    }
+  })
+
+  await fastify.post(
+    '/',
+    {
+      schema: {
+        operationId: 'test',
+        consumes: ['multipart/form-data'],
+        body: {
+          type: 'object',
+          properties: {
+            field: { isFile: true }
+          }
+        }
+      }
+    },
+    async function (req, reply) {
+      reply.send('hello')
+    }
+  )
+
+  await fastify.ready()
+
+  t.match(fastify.swagger(), {
+    paths: {
+      '/': {
+        post: {
+          operationId: 'test',
+          requestBody: {
+            content: {
+              'multipart/form-data': {
+                schema: {
+                  type: 'object',
+                  properties: { field: { type: 'file' } }
+                }
+              }
+            }
+          },
+          responses: {
+            200: { description: 'Default Response' }
+          }
+        }
+      }
+    }
+  })
+})


### PR DESCRIPTION
Previously, there was only one example on how to use `@fastify/multipart` together with `@fastify/swagger`. This PR includes the function in the source code to avoid forcing the programmer to always have to open this documentation to see if anything has been changed. And we can be sure that no developer will ever check this again, where future bugfixes will not be fixed for them.
Also, the previous `type: file` has been changed to an `OpenAPI` compatible `type: string, format: binary`.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)