### PR TITLE
Avoid piping the same file multiple times in case `saveRequestFile` is called twice.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,8 @@ declare module "fastify" {
     ) => Promise<Array<fastifyMultipart.SavedMultipartFile>>;
     cleanRequestFiles: () => Promise<void>;
     tmpUploads: Array<string> | null;
+    /** This will get populated as soon as a call to `saveRequestFiles` gets resolved. Avoiding any future duplicate work */
+    savedRequestFiles: Array<fastifyMultipart.SavedMultipartFile> | null;
   }
 
   interface FastifyInstance {

--- a/index.js
+++ b/index.js
@@ -206,6 +206,7 @@ function fastifyMultipart (fastify, options, done) {
 
   fastify.decorateRequest('isMultipart', isMultipart)
   fastify.decorateRequest('tmpUploads', null)
+  fastify.decorateRequest('savedRequestFiles', null)
 
   // legacy
   fastify.decorateRequest('multipart', handleLegacyMultipartApi)

--- a/test/multipart-duplicate-save-request-file.test.js
+++ b/test/multipart-duplicate-save-request-file.test.js
@@ -1,0 +1,56 @@
+'use strict'
+
+const test = require('tap').test
+const FormData = require('form-data')
+const Fastify = require('fastify')
+const multipart = require('..')
+const http = require('http')
+const path = require('path')
+const fs = require('fs')
+const EventEmitter = require('events')
+const { once } = EventEmitter
+
+const filePath = path.join(__dirname, '../README.md')
+
+test('should store file on disk, remove on response', async function (t) {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  await fastify.register(multipart)
+
+  await fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    const files = await req.saveRequestFiles()
+    const files2 = await req.saveRequestFiles()
+
+    // If it really reused the previously response, their filepath should be the same
+    t.equal(files[0].filepath, files2[0].filepath)
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+})


### PR DESCRIPTION
In cases where multiple hooks and the handler needs to use the saved request files, and they cannot share the first call's result of `saveRequestFile`, they would call it twice or more which would result into piping the same file to disk more than once. As we can check by the following code:

```ts
fastify.post('/', async (req, rep) => {
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a01.txt' }]
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a02.txt' }]
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a03.txt' }]
})
```

Now, `saveRequestFiles` will use the same system file and do not write the disk more than needed.

```ts
fastify.post('/', async (req, rep) => {
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a04.txt' }]
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a04.txt' }]
  await req.saveRequestFiles() // [{ filepath: '/tmp/0388009396720a04.txt' }]
  //                                       (Same filepath) ⬆️

  // where they are saved
  req.savedRequestFiles // [{ filepath: '/tmp/0388009396720a04.txt' }]
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
