### PR TITLE
fix: Empty body handling when attachFieldsToBody is keyValues

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,19 +165,21 @@ function fastifyMultipart (fastify, options, done) {
       }
       if (options.attachFieldsToBody === 'keyValues') {
         const body = {}
-        for (const key of Object.keys(req.body)) {
-          const field = req.body[key]
-          if (field.value !== undefined) {
-            body[key] = field.value
-          } else if (Array.isArray(field)) {
-            body[key] = field.map(item => {
-              if (item._buf !== undefined) {
-                return item._buf.toString()
-              }
-              return item.value
-            })
-          } else if (field._buf !== undefined) {
-            body[key] = field._buf.toString()
+        if (req.body) {
+          for (const key of Object.keys(req.body)) {
+            const field = req.body[key]
+            if (field.value !== undefined) {
+              body[key] = field.value
+            } else if (Array.isArray(field)) {
+              body[key] = field.map(item => {
+                if (item._buf !== undefined) {
+                  return item._buf.toString()
+                }
+                return item.value
+              })
+            } else if (field._buf !== undefined) {
+              body[key] = field._buf.toString()
+            }
           }
         }
         req.body = body

--- a/test/multipart-empty-body.test.js
+++ b/test/multipart-empty-body.test.js
@@ -48,3 +48,45 @@ test('should not break with a empty request body when attachFieldsToBody is true
   await once(res, 'end')
   t.pass('res ended successfully')
 })
+
+test('should not break with a empty request body when attachFieldsToBody is keyValues', async function (t) {
+  t.plan(5)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    const files = await req.saveRequestFiles()
+
+    t.ok(Array.isArray(files))
+    t.equal(files.length, 0)
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})


### PR DESCRIPTION
We encountered `500` errors when `attachFieldsToBody` is set to `keyValues` and an empty body is submitted.

* There's already a test case which covers this scenario for `attachFieldsToBody` set to `true`
* Fixing this for `attachFieldsToBody` set to `keyValues` as well, and extend existing test

`test/big.test.js` fails for me locally, but it was failing before my changes already.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

