### PR TITLE
When options.attachFieldsToBody is set to "keyValues" do not stringify buffer, but return the Buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,12 +172,12 @@ function fastifyMultipart (fastify, options, done) {
           } else if (Array.isArray(field)) {
             body[key] = field.map(item => {
               if (item._buf !== undefined) {
-                return item._buf.toString()
+                return item._buf
               }
               return item.value
             })
           } else if (field._buf !== undefined) {
-            body[key] = field._buf.toString()
+            body[key] = field._buf
           }
         }
         req.body = body


### PR DESCRIPTION
The details that led to the creation of this pull request are described in this issue.

https://github.com/fastify/fastify-multipart/issues/447
