### PR TITLE
Fix file stream consumption when buffer has not loaded yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,12 +172,12 @@ function fastifyMultipart (fastify, options, done) {
               body[key] = field.value
             } else if (Array.isArray(field)) {
               body[key] = field.map(item => {
-                if (item._buf !== undefined) {
+                if (item._buf) {
                   return item._buf.toString()
                 }
                 return item.value
               })
-            } else if (field._buf !== undefined) {
+            } else if (field._buf) {
               body[key] = field._buf.toString()
             }
           }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
---

Hey! This PR fixes #369

Seems like `_buf` is initialized with `null` and its data is being loaded through `part.toBuffer()`. The condition that checks if the field has data in its buffer compares only against `undefined` instead of `null`, leading to an exception when calling `field._buf.toString()` when `_buf === null`.

Let me know if I'm missing something or if something needs to be changed.