### PR TITLE
Return buffers directly when `attachFieldsToBody` is set to `'keyValues'`

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,3 @@
-ts: false
-jsx: false
-flow: false
 check-coverage: false
+files:
+  - test/**/*.test.js

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ fastify.post('/upload/files', async function (req, reply) {
 })
 ```
 
-Request body key-value pairs can be assigned directly using `attachFieldsToBody: 'keyValues'`. Field values will be attached directly to the body object. By default, all files are converted to a string using `buffer.toString()` used as the value attached to the body.
+Request body key-value pairs can be assigned directly using `attachFieldsToBody: 'keyValues'`. Field values including file buffers will be attached to the body object.
 
 ```js
 fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues' })

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Request body key-value pairs can be assigned directly using `attachFieldsToBody:
 fastify.register(require('@fastify/multipart'), { attachFieldsToBody: 'keyValues' })
 
 fastify.post('/upload/files', async function (req, reply) {
-  const uploadValue = req.body.upload // access file as string
+  const uploadValue = req.body.upload // access file as buffer
   const fooValue = req.body.foo       // other fields
 })
 ```

--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ function fastifyMultipart (fastify, options, done) {
   }
 
   const attachFieldsToBody = options.attachFieldsToBody
+
   if (options.addToBody === true) {
     if (typeof options.sharedSchemaId === 'string') {
       fastify.addSchema({
@@ -136,7 +137,7 @@ function fastifyMultipart (fastify, options, done) {
     })
   }
 
-  if (options.attachFieldsToBody === true || options.attachFieldsToBody === 'keyValues') {
+  if (attachFieldsToBody === true || attachFieldsToBody === 'keyValues') {
     if (typeof options.sharedSchemaId === 'string') {
       fastify.addSchema({
         $id: options.sharedSchemaId,
@@ -167,7 +168,7 @@ function fastifyMultipart (fastify, options, done) {
         }
       }
 
-      if (options.attachFieldsToBody === 'keyValues') {
+      if (attachFieldsToBody === 'keyValues') {
         const body = {}
 
         if (req.body) {

--- a/index.js
+++ b/index.js
@@ -172,10 +172,11 @@ function fastifyMultipart (fastify, options, done) {
         const body = {}
 
         if (req.body) {
-          const reqBodyEntries = Object.entries(req.body)
+          const reqBodyKeys = Object.keys(req.body)
 
-          for (let i = 0; i < reqBodyEntries.length; ++i) {
-            const [key, field] = reqBodyEntries[i]
+          for (let i = 0; i < reqBodyKeys.length; ++i) {
+            const key = reqBodyKeys[i]
+            const field = req.body[key]
 
             if (field.value !== undefined) {
               body[key] = field.value

--- a/index.js
+++ b/index.js
@@ -180,9 +180,7 @@ function fastifyMultipart (fastify, options, done) {
             } else if (Array.isArray(field)) {
               const items = []
 
-              for (let i = 0; i < field.length; ++i) {
-                const item = field[i]
-
+              for (const item of field) {
                 if (item.value !== undefined) {
                   items.push(item.value)
                 } else if (item._buf) {

--- a/index.js
+++ b/index.js
@@ -173,12 +173,12 @@ function fastifyMultipart (fastify, options, done) {
             } else if (Array.isArray(field)) {
               body[key] = field.map(item => {
                 if (item._buf) {
-                  return item._buf.toString()
+                  return item._buf
                 }
                 return item.value
               })
             } else if (field._buf) {
-              body[key] = field._buf.toString()
+              body[key] = field._buf
             }
           }
         }

--- a/index.js
+++ b/index.js
@@ -172,7 +172,11 @@ function fastifyMultipart (fastify, options, done) {
         const body = {}
 
         if (req.body) {
-          for (const [key, field] of Object.entries(req.body)) {
+          const reqBodyEntries = Object.entries(req.body)
+
+          for (let i = 0; i < reqBodyEntries.length; ++i) {
+            const [key, field] = reqBodyEntries[i]
+
             if (field.value !== undefined) {
               body[key] = field.value
             } else if (field._buf) {
@@ -180,7 +184,9 @@ function fastifyMultipart (fastify, options, done) {
             } else if (Array.isArray(field)) {
               const items = []
 
-              for (const item of field) {
+              for (let i = 0; i < field.length; ++i) {
+                const item = field[i]
+
                 if (item.value !== undefined) {
                   items.push(item.value)
                 } else if (item._buf) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "start": "CLIMEM=8999 node -r climem ./examples/example",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap \"test/**/*.test.js\" -t 90"
+    "test:unit": "tap -t 90"
   },
   "repository": {
     "type": "git",

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -121,6 +121,8 @@ test('should be able to attach all parsed field values and files and make it acc
   fastify.post('/', async function (req, reply) {
     t.ok(req.isMultipart())
 
+    req.body.upload = req.body.upload.toString('utf8')
+
     t.same(Object.keys(req.body), ['upload', 'hello'])
 
     t.equal(req.body.upload, original)
@@ -307,6 +309,9 @@ test('should manage array fields', async function (t) {
   fastify.post('/', async function (req, reply) {
     t.ok(req.isMultipart())
 
+    req.body.upload[0] = req.body.upload[0].toString('utf8')
+    req.body.upload[1] = req.body.upload[1].toString('utf8')
+
     t.same(req.body, {
       upload: [original, original],
       hello: ['hello', 'world']
@@ -426,6 +431,53 @@ test('should handle file stream consumption when internal buffer is not yet load
 
   const req = http.request(opts)
   form.append('upload', Readable.from(Buffer.from(original).toString('base64')))
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})
+
+test('should pass the buffer instead of convering to string', async function (t) {
+  t.plan(7)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
+
+  const original = fs.readFileSync(filePath)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload', 'hello'])
+
+    t.ok(req.body.upload instanceof Buffer)
+    t.ok(Buffer.compare(req.body.upload, original) === 0)
+    t.equal(req.body.hello, 'world')
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+  form.append('hello', 'world')
   form.pipe(req)
 
   const [res] = await once(req, 'response')


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
Carries over the work of https://github.com/fastify/fastify-multipart/pull/456

Closes #447

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
