### PR TITLE
use `in` to check for prototype violation

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ const secureJSON = require('secure-json-parse')
 
 const kMultipart = Symbol('multipart')
 const kMultipartHandler = Symbol('multipartHandler')
-const getDescriptor = Object.getOwnPropertyDescriptor
 
 const PartsLimitError = createError('FST_PARTS_LIMIT', 'reach parts limit', 413)
 const FilesLimitError = createError('FST_FILES_LIMIT', 'reach files limit', 413)
@@ -249,7 +248,7 @@ function fastifyMultipart (fastify, options, done) {
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated, encoding, contentType) {
       // don't overwrite prototypes
-      if (getDescriptor(Object.prototype, name)) {
+      if (name in Object.prototype) {
         onError(new PrototypeViolationError())
         return
       }
@@ -295,7 +294,7 @@ function fastifyMultipart (fastify, options, done) {
 
     function onFile (name, file, filename, encoding, mimetype) {
       // don't overwrite prototypes
-      if (getDescriptor(Object.prototype, name)) {
+      if (name in Object.prototype) {
         // ensure that stream is consumed, any error is suppressed
         sendToWormhole(file)
         onError(new PrototypeViolationError())

--- a/test/multipart-security.test.js
+++ b/test/multipart-security.test.js
@@ -104,6 +104,141 @@ test('should not allow __proto__ as field name', function (t) {
   })
 })
 
+test('should not allow toString as field name', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.file()
+      reply.code(200).send()
+    } catch (error) {
+      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      reply.code(500).send()
+    }
+  })
+
+  fastify.listen({ port: 0 }, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 500)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('toString', 'world')
+
+    form.pipe(req)
+  })
+})
+
+test('should not allow hasOwnProperty as field name', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.file()
+      reply.code(200).send()
+    } catch (error) {
+      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      reply.code(500).send()
+    }
+  })
+
+  fastify.listen({ port: 0 }, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 500)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('hasOwnProperty', 'world')
+
+    form.pipe(req)
+  })
+})
+
+test('should not allow propertyIsEnumerable as field name', function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    try {
+      await req.file()
+      reply.code(200).send()
+    } catch (error) {
+      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      reply.code(500).send()
+    }
+  })
+
+  fastify.listen({ port: 0 }, async function () {
+    // request
+    const form = new FormData()
+    const opts = {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: fastify.server.address().port,
+      path: '/',
+      headers: form.getHeaders(),
+      method: 'POST'
+    }
+
+    const req = http.request(opts, (res) => {
+      t.equal(res.statusCode, 500)
+      res.resume()
+      res.on('end', () => {
+        t.pass('res ended successfully')
+      })
+    })
+    form.append('propertyIsEnumerable', 'world')
+
+    form.pipe(req)
+  })
+})
+
 test('should use default for fileSize', async function (t) {
   t.plan(4)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
It's 36% faster and provides clearer intent

[Benchmark](https://perf.link/#eyJpZCI6ImwzcnoxZnRxNWxwIiwidGl0bGUiOiJGaW5kaW5nIG51bWJlcnMgaW4gYW4gYXJyYXkgb2YgMTAwMCIsImJlZm9yZSI6ImNvbnN0IHRlc3QgPSB7fSIsInRlc3RzIjpbeyJuYW1lIjoiRmluZCBpdGVtIDEwMCIsImNvZGUiOiJjb25zdCBhID0gXCJ0b1N0cmluZ1wiXG5pZighKGEgaW4gT2JqZWN0LnByb3RvdHlwZSkpIHRlc3RbYV0gPSAnU0FGRSciLCJydW5zIjpbMzc0NDAwMCw1MjcyMDAwLDQxMTAwMCwyNzcyMDAwLDEzMTQwMDAsMjgyODAwMCwxMDY0NTAwMCwxMjgwNzAwMCwxMzE0MDAwLDUwMDAwLDIzMDQwMDAsMTYzNjAwMCwxMTA0MzAwMCwxOTM1OTAwMCwzMjQ3MDAwLDY3MzMwMDAsMTY3MDgwMDAsMTMxNDAwMCw1ODk5MDAwLDE3NDcwMDAsMTIzMTUwMDAsMTM2NDEwMDAsMTY0NDIwMDAsMTQ5NjAwMCw4MTYxMDAwLDI3MDMwMDAsOTE1MjAwMCwxMzY0NDAwMCwyMTAzMzAwMCwzNDkwMDAwLDEyOTQwMDAwLDEwODUxMDAwLDE3Mzk5MDAwLDI0MDgwMDAsMTA1OTcwMDAsMzQ3ODAwMCwxODQzNDAwMCwzNjk0MDAwLDI3OTIwMDAsODg3OTAwMCw1MTUwMDAsNjE1MDAwLDE2OTM5MDAwLDE0NjUwMDAsNzkzMzAwMCwzMzg0MDAwLDc0NzAwMDAsMTY1MjUwMDAsMzQ0NTAwMCwxMDA0MTAwMCwxNTg2MDAwLDk2NjcwMDAsMTc5MTEwMDAsMTg4NTcwMDAsMTMxNDAwMCw5NjQyMDAwLDEyNzc2MDAwLDE4NDUxMDAwLDEzODIwMDAsMTQ2OTAwMCwxNzA0MDAwLDEzMTQwMDAsMjA0NjkwMDAsMzAyMDAwMCw3OTcyMDAwLDIwNDYzMDAwLDIxMzgyMDAwLDE5NTE2MDAwLDMzNTAwMDAsMTMwMDcwMDAsMjcwNzAwMCw0NTU3MDAwLDI5MDAwLDEyMDU2MDAwLDEzMTQwMDAsMTI3MTkwMDAsMjQ4NjAwMCwzOTAxMDAwLDE5NjM5MDAwLDE3NzkwMDAwLDM2OTEwMDAsNzczMjAwMCwyMTQzODAwMCw0Njc2MDAwLDE5MDg2MDAwLDE5NTkwMDAsMjkwMjAwMCwxOTQ3OTAwMCw0Njk1MDAwLDc1MjgwMDAsMzQxMjAwMCwxOTczMDAwLDE4NTUzMDAwLDIxNzYwMDAsNzIxNjAwMCwyNjQ3MDAwLDczMjYwMDAsMTQ3MzQwMDAsMTk3MzAwMCw4Mzg3MDAwXSwib3BzIjo4MTcwNjEwfSx7Im5hbWUiOiJGaW5kIGl0ZW0gMjAwIiwiY29kZSI6ImNvbnN0IGEgPSBcInRvU3RyaW5nXCJcbmlmKCEoT2JqZWN0LmdldE93blByb3BlcnR5RGVzY3JpcHRvcihPYmplY3QucHJvdG90eXBlLCBhKSkpIHRlc3RbYV0gPSAnU0FGRSciLCJydW5zIjpbMTE4NDAwMCwyNDQ0MDAwLDUxNjcwMDAsMjA5NzAwMCw1MTcwMDAsMTE0MDAwMCw1MzcyMDAwLDEwMzU2MDAwLDEzNTQwMDAsMTE5ODQwMDAsMTE4NDAwMCwzMzAxMDAwLDg4MjEwMDAsMTU3NDEwMDAsMTgwOTAwMCwyNjMzMDAwLDE0NTYzMDAwLDY4MzAwMCwzOTMwMDAwLDI3MjAwMCw2MTg2MDAwLDEwNjc3MDAwLDEzMzE5MDAwLDExODQwMDAsNDYxMTAwMCwyMDU5MDAwLDUxMDkwMDAsMTU4MDYwMDAsMTU4MDYwMDAsMjczNzAwMCw3OTE5MDAwLDg1OTAwMDAsMTM5NTkwMDAsMTkyNTAwMCw2ODUyMDAwLDIxNjIwMDAsMTQ4NzQwMDAsMjQ4NTAwMCwyMTM3MDAwLDU5ODYwMDAsMzg1MDAwLDQ2NzAwMCwxMjgwMjAwMCwxODEzMDAwLDYwOTYwMDAsMTkzMDAwMCw0NTQ2MDAwLDIyNjYwMDAsMTY1NTAwMCw2NDczMDAwLDE2ODAwMCw2NTgxMDAwLDE0NDg3MDAwLDE1NjA0MDAwLDExMDUwMDAsNTY5MzAwMCwxMDIxMzAwMCwxNDQ0MTAwMCwxMjU2NjAwMCw1MjYwMDAsNzU2MDAwLDExNjQwMDAsMTU4MDcwMDAsMTY3ODAwMCwzNjcxMDAwLDE1ODA3MDAwLDE1ODA2MDAwLDE1ODA2MDAwLDIwODIwMDAsNjk3MjAwMCwxMTg0MDAwLDMzOTkwMDAsMzQwMDAsODY4NzAwMCw1MDEwMDAsNjc2NTAwMCwxMjY2MDAwLDExODQwMDAsMTU3ODkwMDAsMTMxNjkwMDAsMjExOTAwMCw5NDM3MDAwLDE1OTA2MDAwLDMxNDYwMDAsMTU4MDYwMDAsMTE4NDAwMCwxODg2MDAwLDE1NzMzMDAwLDI4MzEwMDAsNDA0NTAwMCwxNzEyMDAwLDE1MDkwMDAsMTU1MTkwMDAsMTg2MDAwMCw0Mjk1MDAwLDEwOTUwMDAsMzMwNTAwMCw0MjgxMDAwLDExODQwMDAsNTcxMzAwMF0sIm9wcyI6NjAyODQ1MH1dLCJ1cGRhdGVkIjoiMjAyMy0wOS0yOFQyMjo1NzowNy40NDhaIn0%3D)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
