### PR TITLE
use @fastify/busboy v2.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,8 +199,7 @@ function fastifyMultipart (fastify, options, done) {
     const parts = () => {
       return new Promise((resolve, reject) => {
         handle((val) => {
-          if (val instanceof Error) return reject(val)
-          resolve(val)
+          val instanceof Error && val.message !== 'Unexpected end of multipart data' ? reject(val) : resolve(val)
         })
       })
     }

--- a/index.js
+++ b/index.js
@@ -199,7 +199,16 @@ function fastifyMultipart (fastify, options, done) {
     const parts = () => {
       return new Promise((resolve, reject) => {
         handle((val) => {
-          val instanceof Error && val.message !== 'Unexpected end of multipart data' ? reject(val) : resolve(val)
+          if (val instanceof Error) {
+            if (val.message === 'Unexpected end of multipart data') {
+              // Stop parsing without throwing an error
+              resolve(null)
+            } else {
+              reject(val)
+            }
+          } else {
+            resolve(val)
+          }
         })
       })
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "dependencies": {
-    "@fastify/busboy": "^1.0.0",
+    "@fastify/busboy": "^2.1.0",
     "@fastify/deepmerge": "^1.0.0",
     "@fastify/error": "^3.0.0",
     "fastify-plugin": "^4.0.0",


### PR DESCRIPTION
Motivation: busboy@2 is more strict

For now it's not ideal (string comparison) but it works, maybe we can return a standard error message or error code from busboy, like `400`