### PR TITLE
Add FormData decorator to request

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ fastify.post('/upload/files', async function (req, reply) {
   ) // Request body in key-value pairs, like req.body in Express (Node 12+)
 
   // On Node 18+
-  const formData = await req.formdata()
+  const formData = await req.formData()
   console.log(formData)
 })
 ```

--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ fastify.post('/upload/files', async function (req, reply) {
   const body = Object.fromEntries(
     Object.keys(req.body).map((key) => [key, req.body[key].value])
   ) // Request body in key-value pairs, like req.body in Express (Node 12+)
+
+  // On Node 18+
+  const formData = await req.formdata()
+  console.log(formData)
 })
 ```
 
@@ -518,6 +522,7 @@ fastify.post('/upload/files', async function (req, reply) {
 This project is kindly sponsored by:
 - [nearForm](https://nearform.com)
 - [LetzDoIt](https://www.letzdoitapp.com/)
+- [platformatic](https://platformatic.dev)
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const PrototypeViolationError = createError('FST_PROTO_VIOLATION', 'prototype pr
 const InvalidMultipartContentTypeError = createError('FST_INVALID_MULTIPART_CONTENT_TYPE', 'the request is not multipart', 406)
 const InvalidJSONFieldError = createError('FST_INVALID_JSON_FIELD_ERROR', 'a request field is not a valid JSON as declared by its Content-Type', 406)
 const FileBufferNotFoundError = createError('FST_FILE_BUFFER_NOT_FOUND', 'the file buffer was not found', 500)
+const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 500)
 
 function setMultipart (req, payload, done) {
   req[kMultipart] = true
@@ -157,6 +158,12 @@ function fastifyMultipart (fastify, options, done) {
         return formData
       })
     }
+  } 
+
+  if (!fastify.hasRequestDecorator('formData')) {
+    fastify.decorateRequest('formData', async function () {
+      throw new NoFormData()
+    })
   }
 
   const defaultThrowFileSizeLimit = typeof options.throwFileSizeLimit === 'boolean'

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function fastifyMultipart (fastify, options, done) {
     // The following is not available on old Node.js versions
     // so we must skip it in the test coverage
     /* istanbul ignore next */
-    if (globalThis.FormData) {
+    if (globalThis.FormData && !fastify.hasRequestDecorator('formData')) {
       fastify.decorateRequest('formData', async function () {
         const formData = new FormData()
         for (const key in this.body) {

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function fastifyMultipart (fastify, options, done) {
     // so we must skip it in the test coverage
     /* istanbul ignore next */
     if (globalThis.FormData) {
-      fastify.decorateRequest('formdata', async function () {
+      fastify.decorateRequest('formData', async function () {
         const formData = new FormData()
         for (const key in this.body) {
           const value = this.body[key]

--- a/index.js
+++ b/index.js
@@ -158,7 +158,7 @@ function fastifyMultipart (fastify, options, done) {
         return formData
       })
     }
-  } 
+  }
 
   /* istanbul ignore next */
   if (!fastify.hasRequestDecorator('formData')) {

--- a/index.js
+++ b/index.js
@@ -142,7 +142,7 @@ function fastifyMultipart (fastify, options, done) {
         }
 
         async function append (key, entry) {
-          if (entry.type === 'file') {
+          if (entry.type === 'file' || (attachFieldsToBody === 'keyValues' && Buffer.isBuffer(entry))) {
             // TODO use File constructor with fs.openAsBlob()
             // if attachFieldsToBody is not set
             // https://nodejs.org/api/fs.html#fsopenasblobpath-options

--- a/index.js
+++ b/index.js
@@ -160,6 +160,7 @@ function fastifyMultipart (fastify, options, done) {
     }
   } 
 
+  /* istanbul ignore next */
   if (!fastify.hasRequestDecorator('formData')) {
     fastify.decorateRequest('formData', async function () {
       throw new NoFormData()

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -504,7 +504,7 @@ test('should be able to attach all parsed fields and files and make it accessibl
 
     t.same(Object.keys(req.body), ['upload', 'hello'])
 
-    const formData = await req.formdata()
+    const formData = await req.formData()
 
     t.equal(formData instanceof globalThis.FormData, true)
     t.equal(formData.get('hello'), 'world')

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -487,7 +487,6 @@ test('should pass the buffer instead of converting to string', async function (t
   t.pass('res ended successfully')
 })
 
-
 const hasGlobalFormData = typeof globalThis.FormData === 'function'
 
 test('should be able to attach all parsed fields and files and make it accessible through "req.formdata"', { skip: !hasGlobalFormData }, async function (t) {

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -486,3 +486,59 @@ test('should pass the buffer instead of converting to string', async function (t
   await once(res, 'end')
   t.pass('res ended successfully')
 })
+
+
+const hasGlobalFormData = typeof globalThis.FormData === 'function'
+
+test('should be able to attach all parsed fields and files and make it accessible through "req.formdata"', { skip: !hasGlobalFormData }, async function (t) {
+  t.plan(10)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, { attachFieldsToBody: true })
+
+  const original = fs.readFileSync(filePath, 'utf8')
+
+  fastify.post('/', async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload', 'hello'])
+
+    const formData = await req.formdata()
+
+    t.equal(formData instanceof globalThis.FormData, true)
+    t.equal(formData.get('hello'), 'world')
+    t.same(formData.getAll('hello'), ['world', 'foo'])
+    t.equal(await formData.get('upload').text(), original)
+    t.equal(formData.get('upload').type, 'text/markdown')
+    t.equal(formData.get('upload').name, 'README.md')
+
+    reply.code(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(filePath))
+  form.append('hello', 'world')
+  form.append('hello', 'foo')
+  form.pipe(req)
+
+  const [res] = await once(req, 'response')
+  t.equal(res.statusCode, 200)
+  res.resume()
+  await once(res, 'end')
+  t.pass('res ended successfully')
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,8 @@ declare module 'fastify' {
   interface FastifyRequest {
     isMultipart: () => boolean;
 
+    formData: () => Promise<FormData>;
+
     // promise api
     parts: (
       options?: Omit<BusboyConfig, 'headers'>

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -24,6 +24,7 @@ const runServer = async () => {
 
   // usage
   app.post('/', async (req, reply) => {
+    expectType<Promise<FormData>>(req.formData())
     const data = await req.file()
     if (data == null) throw new Error('missing file')
 


### PR DESCRIPTION
Adds a tiny helper to create a `FormData` object for compatibility with Web Standards.