### PR TITLE
Support firebase

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 
 function setMultipart (req, payload, done) {
   req[kMultipart] = true
   req.rawBody = payload.rawBody
+  fastify.decorateRequest('rawBody', req.rawBody)
   done()
 }
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 
 
 function setMultipart (req, payload, done) {
   req[kMultipart] = true
+  req.rawBody = payload.rawBody
   done()
 }
 
@@ -297,7 +298,11 @@ function fastifyMultipart (fastify, options, done) {
       process.nextTick(() => cleanup(err))
     })
 
-    request.pipe(bb)
+    if (request.rawBody) {
+      bb.end(request.rawBody)
+    } else {
+      request.pipe(bb)
+    }
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated, encoding, contentType) {
       // don't overwrite prototypes

--- a/index.js
+++ b/index.js
@@ -30,7 +30,6 @@ const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 
 function setMultipart (req, payload, done) {
   req[kMultipart] = true
   req.rawBody = payload.rawBody
-  fastify.decorateRequest('rawBody', req.rawBody)
   done()
 }
 
@@ -182,6 +181,8 @@ function fastifyMultipart (fastify, options, done) {
     RequestFileTooLargeError,
     FileBufferNotFoundError
   })
+
+  fastify.decorateRequest('rawBody', null)
 
   fastify.addContentTypeParser('multipart/form-data', setMultipart)
   fastify.decorateRequest(kMultipart, false)


### PR DESCRIPTION
Currently we can't use this plugin with [serverless](https://fastify.dev/docs/latest/Guides/Serverless/) GCP (or Firebase).

As explained here https://github.com/fastify/fastify/issues/946#issuecomment-766319521 and [in the doc for firebase](https://fastify.dev/docs/latest/Guides/Serverless/#add-custom-contenttypeparser-to-fastify-instance-and-define-endpoints), we need to use `req.rawBody` in order to parse files from multipart.