### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import { BusboyConfig, BusboyFileStream } from '@fastify/busboy'
 import { FastifyPluginCallback, FastifyRequest } from 'fastify'
-import { Readable } from 'stream'
+import { Readable } from 'node:stream'
 import { FastifyErrorConstructor } from '@fastify/error'
 
 declare module 'fastify' {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import fastify from 'fastify'
 import fastifyMultipart, { MultipartValue, MultipartFields, MultipartFile } from '..'
-import * as util from 'util'
-import { pipeline } from 'stream'
-import * as fs from 'fs'
+import * as util from 'node:util'
+import { pipeline } from 'node:stream'
+import * as fs from 'node:fs'
 import { expectError, expectType } from 'tsd'
 import { FastifyErrorConstructor } from '@fastify/error'
 import { BusboyConfig, BusboyFileStream } from '@fastify/busboy'


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.