### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "benchmark": "^2.1.4",
     "climem": "^2.0.0",
     "concat-stream": "^2.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "form-data": "^4.0.0",
     "h2url": "^0.2.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.