### PR TITLE
Add example with fastify-type-provider-zod for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,8 +510,8 @@ fastify.post('/upload/files', {
 To validate requests using [Zod](https://github.com/colinhacks/zod), you need to:
 
 1. Install and configure [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod).
-2. Make sure the `attachFieldsToBody` option is set to `true` when registering the `@fastify/multipart` plugin.
-3. You can use `attachFieldsToBody: "keyValues"` to avoid another fields preprocessing, but in that case, you will receive a Buffer for files that are not text/plain.
+1. Make sure the `attachFieldsToBody` option is set to `true` when registering the `@fastify/multipart` plugin.
+1. You can use `attachFieldsToBody: "keyValues"` to avoid another fields preprocessing, but in that case, you will receive a Buffer for files that are not text/plain.
 
 After setup, you can validate your request body using a Zod schema as usual.
 

--- a/README.md
+++ b/README.md
@@ -507,63 +507,14 @@ fastify.post('/upload/files', {
 
 ## Zod Schema body validation
 
-To validate request using Zod you will need to use [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod) and the `attachFieldsToBody` parameter needs to be `true`, after setting it up, you can validate your request using zod.
+To validate requests using [Zod](https://github.com/colinhacks/zod), you need to:
 
-```js
-import { fastifyMultipart, type MultipartFile } from '@fastify/multipart'
-import {
-  jsonSchemaTransform,
-  serializerCompiler,
-  validatorCompiler,
-  ZodTypeProvider,
-} from 'fastify-type-provider-zod'
+1. Install and configure [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod).
+2. Make sure the `attachFieldsToBody` option is set to `true` when registering the `@fastify/multipart` plugin.
 
-const app = fastify().withTypeProvider<ZodTypeProvider>()
+After setup, you can validate your request body using a Zod schema as usual.
 
-app.setSerializerCompiler(serializerCompiler)
-app.setValidatorCompiler(validatorCompiler)
-
-app.register(fastifyMultipart, { attachFieldsToBody: true })
-
-app.post('/upload/files', {
-  schema: {
-    consumes: ['multipart/form-data'],
-    body: z.object({
-      file: z.custom<MultipartFile>()
-    })
-  }
-}, function (req, reply) {
-  console.log({ body: req.body })
-  reply.send('done')
-})
-```
-
-**Note**: Zod doesn't have native support for `FormData`, so you will need to use refinements, for more information, consult [`zod documentation`](https://zod.dev/?id=refine).
-Similarly `fastify-type-provider-zod` doesn't have support for `Swagger`, you can just disable it for this request with `hide: true`.
-
-```js
-
-fastify.post('/upload/files', {
-  schema: {
-    hide: true, // Disable Swagger
-    consumes: ['multipart/form-data'],
-    body: z.object({
-      file: z
-      .custom<MultipartFile>()
-      .refine((file) => file.file.bytesRead <= 10 * 1024 * 1024, {
-        message: 'The image must be a maximum of 10MB.',
-      })
-      .refine((file) => file.mimetype.startsWith('image'), {
-        message: 'Only images are allowed to be sent.',
-      })
-    })
-  }
-}, function (req, reply) {
-  console.log({ body: req.body })
-  reply.send('done')
-})
-
-```
+See a full example in [`examples/example-with-zod.ts`](examples/example-with-zod.ts).
 
 ## Access all errors
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ To validate requests using [Zod](https://github.com/colinhacks/zod), you need to
 
 1. Install and configure [`fastify-type-provider-zod`](https://github.com/turkerdev/fastify-type-provider-zod).
 2. Make sure the `attachFieldsToBody` option is set to `true` when registering the `@fastify/multipart` plugin.
+3. You can use `attachFieldsToBody: "keyValues"` to avoid another fields preprocessing, but in that case, you will receive a Buffer for files that are not text/plain.
 
 After setup, you can validate your request body using a Zod schema as usual.
 

--- a/examples/example-with-zod.ts
+++ b/examples/example-with-zod.ts
@@ -23,7 +23,10 @@ app.post(
       body: z.object({
         image: z
           .custom<MultipartFile>()
-          .refine((file) => file?.file.bytesRead <= 10 * 1024 * 1024, {
+          .refine((file) => file?.file, {
+            message: 'The image is required.',
+          })
+          .refine((file) => file.file?.bytesRead <= 10 * 1024 * 1024, {
             message: 'The image must be a maximum of 10MB.',
           })
           .refine((file) => file.mimetype.startsWith('image'), {

--- a/examples/example-with-zod.ts
+++ b/examples/example-with-zod.ts
@@ -1,0 +1,54 @@
+import fastifyMultipart, { type MultipartFile } from '@fastify/multipart'
+import fastify from 'fastify'
+import {
+  serializerCompiler,
+  validatorCompiler,
+  type ZodTypeProvider,
+} from 'fastify-type-provider-zod'
+import { z } from 'zod'
+
+const app = fastify().withTypeProvider<ZodTypeProvider>()
+
+app.setSerializerCompiler(serializerCompiler)
+app.setValidatorCompiler(validatorCompiler)
+
+// `attachFieldsToBody` parameter needs to be `true`
+app.register(fastifyMultipart, { attachFieldsToBody: true })
+
+app.post(
+  '/upload',
+  {
+    schema: {
+      consumes: ['multipart/form-data'],
+      body: z.object({
+        image: z
+          .custom<MultipartFile>()
+          .refine((file) => file?.file.bytesRead <= 10 * 1024 * 1024, {
+            message: 'The image must be a maximum of 10MB.',
+          })
+          .refine((file) => file.mimetype.startsWith('image'), {
+            message: 'Only images are allowed to be sent.',
+          }),
+      }),
+    },
+  },
+  async (request, reply) => {
+    const { image } = request.body
+
+    console.log({
+      filename: image.filename,
+      mimetype: image.mimetype,
+      bytes: image.file.bytesRead,
+    })
+
+    return reply.send('OK')
+  }
+)
+
+app.listen({ port: 8000 }, (err, address) => {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  }
+  console.log(`Server listening at ${address}`)
+})

--- a/examples/example-with-zod.ts
+++ b/examples/example-with-zod.ts
@@ -1,4 +1,7 @@
-import fastifyMultipart, { type MultipartFile } from '@fastify/multipart'
+import fastifyMultipart, {
+  type MultipartFile,
+  type MultipartValue,
+} from '@fastify/multipart'
 import fastify from 'fastify'
 import {
   serializerCompiler,
@@ -12,7 +15,6 @@ const app = fastify().withTypeProvider<ZodTypeProvider>()
 app.setSerializerCompiler(serializerCompiler)
 app.setValidatorCompiler(validatorCompiler)
 
-// `attachFieldsToBody` parameter needs to be `true`
 app.register(fastifyMultipart, { attachFieldsToBody: true })
 
 app.post(
@@ -32,17 +34,19 @@ app.post(
           .refine((file) => file.mimetype.startsWith('image'), {
             message: 'Only images are allowed to be sent.',
           }),
+        anotherField: z.preprocess(
+          (file) => (file as MultipartValue).value,
+          z.string() /* validation here */
+        ),
+        /* another fields here */
       }),
     },
   },
   async (request, reply) => {
-    const { image } = request.body
+    const { image, anotherField } = request.body
 
-    console.log({
-      filename: image.filename,
-      mimetype: image.mimetype,
-      bytes: image.file.bytesRead,
-    })
+    console.log('imageType:', image.mimetype)
+    console.log('anotherField:', anotherField)
 
     return reply.send('OK')
   }

--- a/examples/example-with-zod.ts
+++ b/examples/example-with-zod.ts
@@ -29,10 +29,10 @@ app.post(
           .refine((file) => file?.file, {
             message: 'The image is required.',
           })
-          .refine((file) => file.file?.bytesRead <= 10 * 1024 * 1024, {
+          .refine((file) => !file || file.file?.bytesRead <= 10 * 1024 * 1024, {
             message: 'The image must be a maximum of 10MB.',
           })
-          .refine((file) => file.mimetype.startsWith('image'), {
+          .refine((file) => !file || file.mimetype.startsWith('image'), {
             message: 'Only images are allowed to be sent.',
           }),
         anotherField: z.preprocess(

--- a/examples/example-with-zod.ts
+++ b/examples/example-with-zod.ts
@@ -16,6 +16,7 @@ app.setSerializerCompiler(serializerCompiler)
 app.setValidatorCompiler(validatorCompiler)
 
 app.register(fastifyMultipart, { attachFieldsToBody: true })
+// You can use attachFieldsToBody: "keyValues" to avoid another fields preprocessing, but in that case, you will receive a Buffer for files that are not text/plain.
 
 app.post(
   '/upload',


### PR DESCRIPTION
This PR enhances the project documentation by adding a new use case for body validation using Zod in conjunction with `fastify-type-provider-zod`. The example demonstrates how to validate multipart form-data requests, including custom refinements for file size and type validation.

#### Changes Made:
- Added a new section in the README.md titled "Zod Schema body validation".
- Provided a step-by-step guide for integrating Zod with Fastify.
- Included example code for setting up multipart validation with zod.
- Added refinements examples for file size (maximum 10MB) and type (only images).
- Clarified limitations with Zod (FormData support) and fastify-type-provider-zod (Swagger support).

#### Checklist

- [x] Documentation is changed or added.
- [x] Verified example code is functional.
