### PR TITLE
fix(typing): remove unused `MultipartHandler`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,7 +43,7 @@ type FastifyMultipartPlugin = FastifyPluginCallback<
 | fastifyMultipart.FastifyMultipartAttachFieldsToBodyOptions
 >
 
-type MultipartHandler = (
+export type MultipartHandler = (
   field: string,
   file: BusboyFileStream,
   filename: string,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -43,14 +43,6 @@ type FastifyMultipartPlugin = FastifyPluginCallback<
 | fastifyMultipart.FastifyMultipartAttachFieldsToBodyOptions
 >
 
-export type MultipartHandler = (
-  field: string,
-  file: BusboyFileStream,
-  filename: string,
-  encoding: string,
-  mimetype: string
-) => void
-
 interface BodyEntry {
   data: Buffer;
   filename: string;


### PR DESCRIPTION
In the canary tests for the `neostandard` lockfile maintenance it was discovered that with the latest dependencies one error that had previously not been found in `fastify-multipart` was now found: https://github.com/neostandard/neostandard/pull/258

This fixes that error by exporting the interface that's unused.

An alternative would be to remove it instead.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] ~~run `npm run test` and `npm run benchmark`~~
- [ ] ~~tests and/or benchmarks are included~~
- [ ] ~~documentation is changed or added~~
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
