### PR TITLE
Migrate from tap to Node Test Runner

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,0 @@
-files:
-  - test/**/*.test.js

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fastify/busboy": "^3.0.0",
     "@fastify/deepmerge": "^3.0.0",
     "@fastify/error": "^4.0.0",
+    "c8": "^10.1.3",
     "fastify-plugin": "^5.0.0",
     "secure-json-parse": "^4.0.0"
   },
@@ -31,14 +32,13 @@
     "tsd": "^0.33.0"
   },
   "scripts": {
-    "coverage": "npm run test:unit -- --coverage-report=html",
     "climem": "climem 8999 localhost",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "start": "CLIMEM=8999 node -r climem ./examples/example",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "node --test"
+    "test:unit": "c8 --100 node --test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "noop-stream": "^0.1.0",
     "pump": "^3.0.0",
     "readable-stream": "^4.5.2",
-    "tap": "^18.6.1",
     "tsd": "^0.33.0"
   },
   "scripts": {
@@ -39,7 +38,7 @@
     "start": "CLIMEM=8999 node -r climem ./examples/example",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap -t 120"
+    "test:unit": "node --test"
   },
   "repository": {
     "type": "git",

--- a/test/fix-313.test.js
+++ b/test/fix-313.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -17,38 +17,38 @@ test('should store file on disk, remove on response when attach fields to body i
   t.plan(25)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     attachFieldsToBody: true
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const files = await req.saveRequestFiles()
 
-    t.ok(files[0].filepath)
-    t.equal(files[0].type, 'file')
-    t.equal(files[0].fieldname, 'upload')
-    t.equal(files[0].filename, 'README.md')
-    t.equal(files[0].encoding, '7bit')
-    t.equal(files[0].mimetype, 'text/markdown')
-    t.ok(files[0].fields.upload)
-    t.ok(files[1].filepath)
-    t.equal(files[1].type, 'file')
-    t.equal(files[1].fieldname, 'upload')
-    t.equal(files[1].filename, 'README.md')
-    t.equal(files[1].encoding, '7bit')
-    t.equal(files[1].mimetype, 'text/markdown')
-    t.ok(files[1].fields.upload)
-    t.ok(files[2].filepath)
-    t.equal(files[2].type, 'file')
-    t.equal(files[2].fieldname, 'other')
-    t.equal(files[2].filename, 'README.md')
-    t.equal(files[2].encoding, '7bit')
-    t.equal(files[2].mimetype, 'text/markdown')
-    t.ok(files[2].fields.upload)
+    t.assert.ok(files[0].filepath)
+    t.assert.strictEqual(files[0].type, 'file')
+    t.assert.strictEqual(files[0].fieldname, 'upload')
+    t.assert.strictEqual(files[0].filename, 'README.md')
+    t.assert.strictEqual(files[0].encoding, '7bit')
+    t.assert.strictEqual(files[0].mimetype, 'text/markdown')
+    t.assert.ok(files[0].fields.upload)
+    t.assert.ok(files[1].filepath)
+    t.assert.strictEqual(files[1].type, 'file')
+    t.assert.strictEqual(files[1].fieldname, 'upload')
+    t.assert.strictEqual(files[1].filename, 'README.md')
+    t.assert.strictEqual(files[1].encoding, '7bit')
+    t.assert.strictEqual(files[1].mimetype, 'text/markdown')
+    t.assert.ok(files[1].fields.upload)
+    t.assert.ok(files[2].filepath)
+    t.assert.strictEqual(files[2].type, 'file')
+    t.assert.strictEqual(files[2].fieldname, 'other')
+    t.assert.strictEqual(files[2].filename, 'README.md')
+    t.assert.strictEqual(files[2].encoding, '7bit')
+    t.assert.strictEqual(files[2].mimetype, 'text/markdown')
+    t.assert.ok(files[2].fields.upload)
 
     await access(files[0].filepath, fs.constants.F_OK)
     await access(files[1].filepath, fs.constants.F_OK)
@@ -63,8 +63,8 @@ test('should store file on disk, remove on response when attach fields to body i
     try {
       await access(request.tmpUploads[0], fs.constants.F_OK)
     } catch (error) {
-      t.equal(error.code, 'ENOENT')
-      t.pass('Temp file was removed after response')
+      t.assert.strictEqual(error.code, 'ENOENT')
+      t.assert.ok('Temp file was removed after response')
       ee.emit('response')
     }
   })
@@ -89,7 +89,7 @@ test('should store file on disk, remove on response when attach fields to body i
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
   await once(ee, 'response')
@@ -99,7 +99,7 @@ test('should throw on saving request files when attach fields to body is true bu
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     attachFieldsToBody: true,
@@ -111,13 +111,13 @@ test('should throw on saving request files when attach fields to body is true bu
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.saveRequestFiles()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.FileBufferNotFoundError)
+      t.assert.ok(error instanceof fastify.multipartErrors.FileBufferNotFoundError)
       reply.code(500).send()
     }
   })
@@ -140,7 +140,7 @@ test('should throw on saving request files when attach fields to body is true bu
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 500)
+  t.assert.strictEqual(res.statusCode, 500)
   res.resume()
   await once(res, 'end')
 })

--- a/test/generate-id.test.js
+++ b/test/generate-id.test.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const { generateId } = require('../lib/generateId')
 
 test('returns', t => {
   t.plan(3)
-  t.type(generateId, 'function', 'is a function')
-  t.type(generateId(), 'string', '~> returns a string')
-  t.equal(generateId().length, 16, '~> has 16 characters (default)')
+  t.assert.strictEqual(typeof generateId, 'function', 'is a function')
+  t.assert.strictEqual(typeof generateId(), 'string', '~> returns a string')
+  t.assert.strictEqual(generateId().length, 16, '~> has 16 characters (default)')
 })
 
 test('length', t => {
@@ -18,18 +18,18 @@ test('length', t => {
   let tmp = ''
   for (; i < iterations; ++i) {
     tmp = generateId()
-    t.equal(tmp.length, 16, `"${tmp}" is 16 characters`)
+    t.assert.strictEqual(tmp.length, 16, `"${tmp}" is 16 characters`)
   }
 })
 
 test('unique /1', t => {
   t.plan(1)
-  t.not(generateId(), generateId(), '~> single')
+  t.assert.notStrictEqual(generateId(), generateId(), '~> single')
 })
 
 test('unique /2', t => {
   t.plan(1)
   const items = new Set()
   for (let i = 5e6; i--;) items.add(generateId())
-  t.equal(items.size, 5e6, '~> 5,000,000 unique ids')
+  t.assert.strictEqual(items.size, 5e6, '~> 5,000,000 unique ids')
 })

--- a/test/multipart-ajv-file.test.js
+++ b/test/multipart-ajv-file.test.js
@@ -52,7 +52,7 @@ test('show modify the generated schema', async t => {
 
   await fastify.ready()
 
-  t.assert.deepEqual(fastify.swagger().paths, {
+  t.assert.deepStrictEqual(fastify.swagger().paths, {
     '/': {
       post: {
         operationId: 'test',

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -26,7 +26,7 @@ test('should be able to attach all parsed fields and files and make it accessibl
 
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 
@@ -74,9 +74,9 @@ test('should be able to attach all parsed field values and json content files an
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
-    t.assert.deepEqual(req.body.upload, original)
+    t.assert.deepStrictEqual(req.body.upload, original)
     t.assert.strictEqual(req.body.hello, 'world')
 
     reply.code(200).send()
@@ -122,7 +122,7 @@ test('should be able to attach all parsed field values and files and make it acc
 
     req.body.upload = req.body.upload.toString('utf8')
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     t.assert.strictEqual(req.body.upload, original)
     t.assert.strictEqual(req.body.hello, 'world')
@@ -174,7 +174,7 @@ test('should be able to attach all parsed field values and files with custom "on
 
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     t.assert.strictEqual(req.body.upload, original)
     t.assert.strictEqual(req.body.hello, 'world')
@@ -225,7 +225,7 @@ test('should be able to define a custom "onFile" handler', async function (t) {
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 
@@ -312,7 +312,7 @@ test('should manage array fields', async function (t) {
     req.body.upload[0] = req.body.upload[0].toString('utf8')
     req.body.upload[1] = req.body.upload[1].toString('utf8')
 
-    t.assert.deepEqual(req.body, {
+    t.assert.deepStrictEqual(req.body, {
       upload: [original, original],
       hello: ['hello', 'world']
     })
@@ -453,7 +453,7 @@ test('should pass the buffer instead of converting to string', async function (t
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     t.assert.ok(req.body.upload instanceof Buffer)
     t.assert.strictEqual(Buffer.compare(req.body.upload, original), 0)
@@ -502,13 +502,13 @@ test('should be able to attach all parsed fields and files and make it accessibl
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const formData = await req.formData()
 
     t.assert.strictEqual(formData instanceof globalThis.FormData, true)
     t.assert.strictEqual(formData.get('hello'), 'world')
-    t.assert.deepEqual(formData.getAll('hello'), ['world', 'foo'])
+    t.assert.deepStrictEqual(formData.getAll('hello'), ['world', 'foo'])
     t.assert.strictEqual(await formData.get('upload').text(), original)
     t.assert.strictEqual(formData.get('upload').type, 'text/markdown')
     t.assert.strictEqual(formData.get('upload').name, 'README.md')

--- a/test/multipart-attach-body.test.js
+++ b/test/multipart-attach-body.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -18,21 +18,20 @@ test('should be able to attach all parsed fields and files and make it accessibl
   t.plan(6)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true })
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
-
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.ok(req.isMultipart())
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 
-    t.equal(content.toString(), original)
-    t.equal(req.body.hello.value, 'world')
+    t.assert.strictEqual(content.toString(), original)
+    t.assert.strictEqual(req.body.hello.value, 'world')
 
     reply.code(200).send()
   })
@@ -56,29 +55,29 @@ test('should be able to attach all parsed fields and files and make it accessibl
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should be able to attach all parsed field values and json content files and make it accessible through "req.body"', async function (t) {
   t.plan(6)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   const original = { testContent: 'test upload content' }
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
-    t.same(req.body.upload, original)
-    t.equal(req.body.hello, 'world')
+    t.assert.deepEqual(req.body.upload, original)
+    t.assert.strictEqual(req.body.hello, 'world')
 
     reply.code(200).send()
   })
@@ -102,31 +101,31 @@ test('should be able to attach all parsed field values and json content files an
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should be able to attach all parsed field values and files and make it accessible through "req.body"', async function (t) {
   t.plan(6)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     req.body.upload = req.body.upload.toString('utf8')
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
-    t.equal(req.body.upload, original)
-    t.equal(req.body.hello, 'world')
+    t.assert.strictEqual(req.body.upload, original)
+    t.assert.strictEqual(req.body.hello, 'world')
 
     reply.code(200).send()
   })
@@ -150,20 +149,20 @@ test('should be able to attach all parsed field values and files and make it acc
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should be able to attach all parsed field values and files with custom "onFile" handler and make it accessible through "req.body"', async function (t) {
   t.plan(7)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   async function onFile (part) {
-    t.pass('custom onFile handler')
+    t.assert.ok('custom onFile handler')
     const buff = await part.toBuffer()
     const decoded = Buffer.from(buff.toString(), 'base64').toString()
     part.value = decoded
@@ -174,11 +173,11 @@ test('should be able to attach all parsed field values and files with custom "on
   const original = 'test upload content'
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.ok(req.isMultipart())
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
-    t.equal(req.body.upload, original)
-    t.equal(req.body.hello, 'world')
+    t.assert.strictEqual(req.body.upload, original)
+    t.assert.strictEqual(req.body.hello, 'world')
 
     reply.code(200).send()
   })
@@ -202,20 +201,20 @@ test('should be able to attach all parsed field values and files with custom "on
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should be able to define a custom "onFile" handler', async function (t) {
   t.plan(7)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   async function onFile (part) {
-    t.pass('custom onFile handler')
+    t.assert.ok('custom onFile handler')
     await part.toBuffer()
   }
 
@@ -224,14 +223,14 @@ test('should be able to define a custom "onFile" handler', async function (t) {
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 
-    t.equal(content.toString(), original)
-    t.equal(req.body.hello.value, 'world')
+    t.assert.strictEqual(content.toString(), original)
+    t.assert.strictEqual(req.body.hello.value, 'world')
 
     reply.code(200).send()
   })
@@ -255,17 +254,17 @@ test('should be able to define a custom "onFile" handler', async function (t) {
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
-test('should not process requests with content-type other than multipart', function (t) {
+test('should not process requests with content-type other than multipart', function (t, done) {
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true })
 
@@ -283,13 +282,14 @@ test('should not process requests with content-type other than multipart', funct
       method: 'POST'
     }
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.on('data', function (data) {
-        t.equal(JSON.parse(data).hello, 'world')
+        t.assert.strictEqual(JSON.parse(data).hello, 'world')
       })
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     req.end(JSON.stringify({ name: 'world' }))
@@ -300,19 +300,19 @@ test('should manage array fields', async function (t) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     req.body.upload[0] = req.body.upload[0].toString('utf8')
     req.body.upload[1] = req.body.upload[1].toString('utf8')
 
-    t.same(req.body, {
+    t.assert.deepEqual(req.body, {
       upload: [original, original],
       hello: ['hello', 'world']
     })
@@ -341,22 +341,22 @@ test('should manage array fields', async function (t) {
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should be able to attach all parsed field values and files with custom "onFile" handler with access to request object bind to "this"', async function (t) {
   t.plan(6)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   async function onFile (part) {
-    t.pass('custom onFile handler')
-    t.equal(this.id, 'req-1')
-    t.equal(typeof this, 'object')
+    t.assert.ok('custom onFile handler')
+    t.assert.strictEqual(this.id, 'req-1')
+    t.assert.strictEqual(typeof this, 'object')
     const buff = await part.toBuffer()
     const decoded = Buffer.from(buff.toString(), 'base64').toString()
     part.value = decoded
@@ -367,7 +367,7 @@ test('should be able to attach all parsed field values and files with custom "on
   const original = 'test upload content'
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
     reply.code(200).send()
   })
 
@@ -389,21 +389,21 @@ test('should be able to attach all parsed field values and files with custom "on
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should handle file stream consumption when internal buffer is not yet loaded', async function (t) {
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   async function onFile (part) {
     pump(part.file, writableNoopStream()).once('end', () => {
-      t.pass('stream consumed successfully')
+      t.assert.ok('stream consumed successfully')
     })
   }
 
@@ -412,7 +412,7 @@ test('should handle file stream consumption when internal buffer is not yet load
   const original = 'test upload content'
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
     reply.code(200).send()
   })
 
@@ -434,30 +434,30 @@ test('should handle file stream consumption when internal buffer is not yet load
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should pass the buffer instead of converting to string', async function (t) {
   t.plan(7)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   const original = fs.readFileSync(filePath)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
-    t.ok(req.body.upload instanceof Buffer)
-    t.ok(Buffer.compare(req.body.upload, original) === 0)
-    t.equal(req.body.hello, 'world')
+    t.assert.ok(req.body.upload instanceof Buffer)
+    t.assert.strictEqual(Buffer.compare(req.body.upload, original), 0)
+    t.assert.strictEqual(req.body.hello, 'world')
 
     reply.code(200).send()
   })
@@ -481,10 +481,10 @@ test('should pass the buffer instead of converting to string', async function (t
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 const hasGlobalFormData = typeof globalThis.FormData === 'function'
@@ -493,25 +493,25 @@ test('should be able to attach all parsed fields and files and make it accessibl
   t.plan(10)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true })
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const formData = await req.formData()
 
-    t.equal(formData instanceof globalThis.FormData, true)
-    t.equal(formData.get('hello'), 'world')
-    t.same(formData.getAll('hello'), ['world', 'foo'])
-    t.equal(await formData.get('upload').text(), original)
-    t.equal(formData.get('upload').type, 'text/markdown')
-    t.equal(formData.get('upload').name, 'README.md')
+    t.assert.strictEqual(formData instanceof globalThis.FormData, true)
+    t.assert.strictEqual(formData.get('hello'), 'world')
+    t.assert.deepEqual(formData.getAll('hello'), ['world', 'foo'])
+    t.assert.strictEqual(await formData.get('upload').text(), original)
+    t.assert.strictEqual(formData.get('upload').type, 'text/markdown')
+    t.assert.strictEqual(formData.get('upload').name, 'README.md')
 
     reply.code(200).send()
   })
@@ -536,8 +536,8 @@ test('should be able to attach all parsed fields and files and make it accessibl
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -81,6 +81,6 @@ test('should emit fileSize limitation error during streaming', async function (t
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.fail(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -81,6 +81,6 @@ test('should emit fileSize limitation error during streaming', async function (t
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })

--- a/test/multipart-big-stream.test.js
+++ b/test/multipart-big-stream.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -15,13 +15,13 @@ test('should emit fileSize limitation error during streaming', async function (t
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
   const hashInput = crypto.createHash('sha256')
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
     const part = await req.file({ limits: { fileSize: 16500 } })
     await streamToNull(part.file)
     if (part.file.truncated) {
@@ -50,7 +50,7 @@ test('should emit fileSize limitation error during streaming', async function (t
       total -= n
 
       if (total === 0) {
-        t.pass('finished generating')
+        t.assert.ok('finished generating')
         hashInput.end()
         this.push(null)
       }
@@ -77,10 +77,10 @@ test('should emit fileSize limitation error during streaming', async function (t
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
+    t.assert.strictEqual(res.statusCode, 500)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.fail(error, 'request')
   }
 })

--- a/test/multipart-body-schema.test.js
+++ b/test/multipart-body-schema.test.js
@@ -34,7 +34,7 @@ test('should be able to use JSON schema to validate request', function (t, done)
   }, async function (req, reply) {
     t.assert.ok(req.isMultipart())
 
-    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 

--- a/test/multipart-body-schema.test.js
+++ b/test/multipart-body-schema.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -10,11 +10,11 @@ const fs = require('node:fs')
 
 const filePath = path.join(__dirname, '../README.md')
 
-test('should be able to use JSON schema to validate request', function (t) {
+test('should be able to use JSON schema to validate request', function (t, done) {
   t.plan(7)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true, sharedSchemaId: '#mySharedSchema' })
 
@@ -32,15 +32,15 @@ test('should be able to use JSON schema to validate request', function (t) {
       }
     }
   }, async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload', 'hello'])
+    t.assert.deepEqual(Object.keys(req.body), ['upload', 'hello'])
 
     const content = await req.body.upload.toBuffer()
 
-    t.equal(content.toString(), original)
-    t.equal(req.body.hello.type, 'field')
-    t.equal(req.body.hello.value, 'world')
+    t.assert.strictEqual(content.toString(), original)
+    t.assert.strictEqual(req.body.hello.type, 'field')
+    t.assert.strictEqual(req.body.hello.value, 'world')
 
     reply.code(200).send()
   })
@@ -58,10 +58,11 @@ test('should be able to use JSON schema to validate request', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('upload', fs.createReadStream(filePath))
@@ -70,11 +71,11 @@ test('should be able to use JSON schema to validate request', function (t) {
   })
 })
 
-test('should throw because JSON schema is invalid', function (t) {
+test('should throw because JSON schema is invalid', function (t, done) {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true, sharedSchemaId: '#mySharedSchema' })
 
@@ -114,10 +115,11 @@ test('should throw because JSON schema is invalid', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 400)
+      t.assert.strictEqual(res.statusCode, 400)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('hello', 'world')

--- a/test/multipart-concat.test.js
+++ b/test/multipart-concat.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -10,24 +10,24 @@ const fs = require('node:fs')
 
 const filePath = path.join(__dirname, '../README.md')
 
-test('should be able to get whole buffer by accessing "content" on part', function (t) {
+test('should be able to get whole buffer by accessing "content" on part', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const file = await req.file()
     // lazy load (getter)
     const buf = await file.toBuffer()
 
-    t.equal(buf.toString(), original)
+    t.assert.strictEqual(buf.toString(), original)
 
     reply.code(200).send()
   })
@@ -45,10 +45,11 @@ test('should be able to get whole buffer by accessing "content" on part', functi
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('upload', fs.createReadStream(filePath))
@@ -56,26 +57,26 @@ test('should be able to get whole buffer by accessing "content" on part', functi
   })
 })
 
-test('should be able to access "content" multiple times without reading the stream twice', function (t) {
+test('should be able to access "content" multiple times without reading the stream twice', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   const original = fs.readFileSync(filePath, 'utf8')
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const file = await req.file()
     // lazy load (getter)
     const buf = await file.toBuffer()
     const buf2 = await file.toBuffer()
 
-    t.equal(buf.toString(), original)
-    t.equal(buf2.toString(), original)
+    t.assert.strictEqual(buf.toString(), original)
+    t.assert.strictEqual(buf2.toString(), original)
 
     reply.code(200).send()
   })
@@ -93,10 +94,11 @@ test('should be able to access "content" multiple times without reading the stre
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('upload', fs.createReadStream(filePath))

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -11,7 +11,7 @@ const path = require('node:path')
 const fs = require('node:fs')
 const { access } = require('node:fs').promises
 const EventEmitter = require('node:events')
-const os = require('node:os')
+// const os = require('node:os')
 const { once } = EventEmitter
 
 const filePath = path.join(__dirname, '../README.md')
@@ -237,7 +237,7 @@ test('should not throw on request files cleanup error', { skip: process.platform
 
   fastify.register(require('..'))
 
-  const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), ''))
+  const tmpdir = fs.mkdtempSync(path.join(__dirname, 'tmp'))
 
   fastify.post('/', async function (req, reply) {
     t.assert.ok(req.isMultipart())

--- a/test/multipart-disk.test.js
+++ b/test/multipart-disk.test.js
@@ -178,7 +178,7 @@ test('should throw on file limit error', async function (t) {
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -225,7 +225,7 @@ test('should throw on file save error', async function (t) {
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -276,7 +276,7 @@ test('should not throw on request files cleanup error', { skip: process.platform
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -352,7 +352,7 @@ test('should throw on file limit error, after highWaterMark', async function (t)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 

--- a/test/multipart-duplicate-save-request-file.test.js
+++ b/test/multipart-duplicate-save-request-file.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -16,18 +16,18 @@ test('should store file on disk, remove on response', async function (t) {
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   await fastify.register(multipart)
 
   await fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const files = await req.saveRequestFiles()
     const files2 = await req.saveRequestFiles()
 
     // If it really reused the previously response, their filepath should be the same
-    t.equal(files[0].filepath, files2[0].filepath)
+    t.assert.strictEqual(files[0].filepath, files2[0].filepath)
 
     reply.code(200).send()
   })
@@ -50,7 +50,7 @@ test('should store file on disk, remove on response', async function (t) {
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
 })

--- a/test/multipart-empty-body.test.js
+++ b/test/multipart-empty-body.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -11,17 +11,17 @@ test('should not break with a empty request body when attachFieldsToBody is true
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const files = await req.saveRequestFiles()
 
-    t.ok(Array.isArray(files))
-    t.equal(files.length, 0)
+    t.assert.ok(Array.isArray(files))
+    t.assert.strictEqual(files.length, 0)
 
     reply.code(200).send()
   })
@@ -43,27 +43,27 @@ test('should not break with a empty request body when attachFieldsToBody is true
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })
 
 test('should not break with a empty request body when attachFieldsToBody is keyValues', async function (t) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: 'keyValues' })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const files = await req.saveRequestFiles()
 
-    t.ok(Array.isArray(files))
-    t.equal(files.length, 0)
+    t.assert.ok(Array.isArray(files))
+    t.assert.strictEqual(files.length, 0)
 
     reply.code(200).send()
   })
@@ -85,8 +85,8 @@ test('should not break with a empty request body when attachFieldsToBody is keyV
   form.pipe(req)
 
   const [res] = await once(req, 'response')
-  t.equal(res.statusCode, 200)
+  t.assert.strictEqual(res.statusCode, 200)
   res.resume()
   await once(res, 'end')
-  t.pass('res ended successfully')
+  t.assert.ok('res ended successfully')
 })

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('node:fs')
 const crypto = require('node:crypto')
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -14,7 +14,7 @@ test('should throw fileSize limitation error when consuming the stream', async f
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: true,
@@ -24,16 +24,16 @@ test('should throw fileSize limitation error when consuming the stream', async f
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file()
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       await part.toBuffer()
-      t.fail('it should throw')
+      t.assert.fail('it should throw')
     } catch (error) {
-      t.ok(error)
+      t.assert.ok(error)
       reply.send(error)
     }
   })
@@ -60,11 +60,11 @@ test('should throw fileSize limitation error when consuming the stream', async f
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })
 
@@ -72,7 +72,7 @@ test('should throw fileSize limitation error when consuming the stream MBs', asy
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: true,
@@ -82,16 +82,16 @@ test('should throw fileSize limitation error when consuming the stream MBs', asy
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file()
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       await part.toBuffer()
-      t.fail('it should throw')
+      t.assert.fail('it should throw')
     } catch (error) {
-      t.ok(error)
+      t.assert.ok(error)
       reply.send(error)
     }
   })
@@ -121,13 +121,13 @@ test('should throw fileSize limitation error when consuming the stream MBs', asy
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
 
     fs.unlinkSync(tmpFile)
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })
 
@@ -135,7 +135,7 @@ test('should NOT throw fileSize limitation error when consuming the stream', asy
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: false,
@@ -146,18 +146,18 @@ test('should NOT throw fileSize limitation error when consuming the stream', asy
   const fileInputLength = 600000
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file()
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       const buffer = await part.toBuffer()
-      t.ok(part.file.truncated)
-      t.notSame(buffer.length, fileInputLength)
+      t.assert.ok(part.file.truncated)
+      t.assert.notStrictEqual(buffer.length, fileInputLength)
       reply.send(new fastify.multipartErrors.FilesLimitError())
     } catch {
-      t.fail('it should not throw')
+      t.assert.ifError('it should not throw')
     }
   })
 
@@ -184,10 +184,10 @@ test('should NOT throw fileSize limitation error when consuming the stream', asy
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })
 
@@ -196,7 +196,7 @@ test('should throw fileSize limitation error when throwFileSizeLimit is globally
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: false,
@@ -206,7 +206,7 @@ test('should throw fileSize limitation error when throwFileSizeLimit is globally
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file({
       throwFileSizeLimit: true,
@@ -214,13 +214,13 @@ test('should throw fileSize limitation error when throwFileSizeLimit is globally
         fileSize: 524288
       }
     })
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       await part.toBuffer()
-      t.fail('it should throw')
+      t.assert.fail('it should throw')
     } catch (error) {
-      t.ok(error)
+      t.assert.ok(error)
       reply.send(error)
     }
   })
@@ -247,11 +247,11 @@ test('should throw fileSize limitation error when throwFileSizeLimit is globally
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })
 
@@ -259,7 +259,7 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: true,
@@ -270,20 +270,20 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
   const fileInputLength = 600_000
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file({
       throwFileSizeLimit: false
     })
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       const buffer = await part.toBuffer()
-      t.ok(part.file.truncated)
-      t.notSame(buffer.length, fileInputLength)
+      t.assert.ok(part.file.truncated)
+      t.assert.notStrictEqual(buffer.length, fileInputLength)
       reply.send(new fastify.multipartErrors.FilesLimitError())
     } catch {
-      t.fail('it should not throw')
+      t.assert.ifError('it should not throw')
     }
   })
 
@@ -310,9 +310,9 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -64,7 +64,7 @@ test('should throw fileSize limitation error when consuming the stream', async f
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -127,7 +127,7 @@ test('should throw fileSize limitation error when consuming the stream MBs', asy
 
     fs.unlinkSync(tmpFile)
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -187,7 +187,7 @@ test('should NOT throw fileSize limitation error when consuming the stream', asy
     t.assert.strictEqual(res.statusCode, 413)
     res.resume()
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -251,7 +251,7 @@ test('should throw fileSize limitation error when throwFileSizeLimit is globally
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -313,6 +313,6 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
     t.assert.strictEqual(res.statusCode, 413)
     res.resume()
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -157,7 +157,7 @@ test('should NOT throw fileSize limitation error when consuming the stream', asy
       t.assert.notStrictEqual(buffer.length, fileInputLength)
       reply.send(new fastify.multipartErrors.FilesLimitError())
     } catch {
-      t.assert.ifError('it should not throw')
+      t.assert.fail('it should not throw')
     }
   })
 
@@ -283,7 +283,7 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
       t.assert.notStrictEqual(buffer.length, fileInputLength)
       reply.send(new fastify.multipartErrors.FilesLimitError())
     } catch {
-      t.assert.ifError('it should not throw')
+      t.assert.fail('it should not throw')
     }
   })
 

--- a/test/multipart-http2.test.js
+++ b/test/multipart-http2.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -11,16 +11,16 @@ const streamToNull = require('../lib/stream-consumer')
 
 const filePath = path.join(__dirname, '../README.md')
 
-test('should respond when all files are processed', function (t) {
+test('should respond when all files are processed', function (t, done) {
   const fastify = Fastify({ http2: true })
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     const parts = req.files()
     for await (const part of parts) {
-      t.ok(part.file)
+      t.assert.ok(part.file)
       await streamToNull(part.file)
     }
     reply.code(200).send()
@@ -37,7 +37,7 @@ test('should respond when all files are processed', function (t) {
 
     const res = await h2url.concat({ url, method: 'POST', headers: form.getHeaders(), body: form })
 
-    t.equal(res.headers[':status'], 200)
-    t.end()
+    t.assert.strictEqual(res.headers[':status'], 200)
+    done()
   })
 })

--- a/test/multipart-http2.test.js
+++ b/test/multipart-http2.test.js
@@ -12,6 +12,8 @@ const streamToNull = require('../lib/stream-consumer')
 const filePath = path.join(__dirname, '../README.md')
 
 test('should respond when all files are processed', function (t, done) {
+  t.plan(3)
+
   const fastify = Fastify({ http2: true })
   t.after(() => fastify.close())
 

--- a/test/multipart-json.test.js
+++ b/test/multipart-json.test.js
@@ -18,7 +18,7 @@ test('should parse JSON fields forms if content-type is set', function (t, done)
     for await (const part of req.parts()) {
       t.assert.strictEqual(part.filename, undefined)
       t.assert.strictEqual(part.mimetype, 'application/json')
-      t.assert.deepEqual(part.value, { a: 'b' })
+      t.assert.deepStrictEqual(part.value, { a: 'b' })
     }
 
     reply.code(200).send()
@@ -263,7 +263,7 @@ test('should be able to use JSON schema to validate request when value is a stri
     async function (req, reply) {
       t.assert.ok(req.isMultipart())
 
-      t.assert.deepEqual(Object.keys(req.body), ['field'])
+      t.assert.deepStrictEqual(Object.keys(req.body), ['field'])
       t.assert.strictEqual(req.body.field.value, '{"a":"b"}')
 
       reply.code(200).send()
@@ -322,8 +322,8 @@ test('should be able to use JSON schema to validate request when value is a JSON
     async function (req, reply) {
       t.assert.ok(req.isMultipart())
 
-      t.assert.deepEqual(Object.keys(req.body), ['field'])
-      t.assert.deepEqual(req.body.field.value, { a: 'b' })
+      t.assert.deepStrictEqual(Object.keys(req.body), ['field'])
+      t.assert.deepStrictEqual(req.body.field.value, { a: 'b' })
 
       reply.code(200).send()
     }

--- a/test/multipart-json.test.js
+++ b/test/multipart-json.test.js
@@ -1,24 +1,24 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
 const http = require('node:http')
 
-test('should parse JSON fields forms if content-type is set', function (t) {
+test('should parse JSON fields forms if content-type is set', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     for await (const part of req.parts()) {
-      t.notOk(part.filename)
-      t.equal(part.mimetype, 'application/json')
-      t.same(part.value, { a: 'b' })
+      t.assert.strictEqual(part.filename, undefined)
+      t.assert.strictEqual(part.mimetype, 'application/json')
+      t.assert.deepEqual(part.value, { a: 'b' })
     }
 
     reply.code(200).send()
@@ -37,10 +37,11 @@ test('should parse JSON fields forms if content-type is set', function (t) {
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -49,19 +50,19 @@ test('should parse JSON fields forms if content-type is set', function (t) {
   })
 })
 
-test('should not parse JSON fields forms if no content-type is set', function (t) {
+test('should not parse JSON fields forms if no content-type is set', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     for await (const part of req.parts()) {
-      t.notOk(part.filename)
-      t.equal(part.mimetype, 'text/plain')
-      t.type(part.value, 'string')
+      t.assert.strictEqual(part.filename, undefined)
+      t.assert.strictEqual(part.mimetype, 'text/plain')
+      t.assert.strictEqual(typeof part.value, 'string')
     }
 
     reply.code(200).send()
@@ -80,10 +81,11 @@ test('should not parse JSON fields forms if no content-type is set', function (t
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -93,19 +95,19 @@ test('should not parse JSON fields forms if no content-type is set', function (t
   })
 })
 
-test('should not parse JSON fields forms if non-json content-type is set', function (t) {
+test('should not parse JSON fields forms if non-json content-type is set', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     for await (const part of req.parts()) {
-      t.notOk(part.filename)
-      t.equal(part.mimetype, 'text/css')
-      t.type(part.value, 'string')
+      t.assert.strictEqual(part.filename, undefined)
+      t.assert.strictEqual(part.mimetype, 'text/css')
+      t.assert.strictEqual(typeof part.value, 'string')
     }
 
     reply.code(200).send()
@@ -124,10 +126,11 @@ test('should not parse JSON fields forms if non-json content-type is set', funct
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -137,23 +140,23 @@ test('should not parse JSON fields forms if non-json content-type is set', funct
   })
 })
 
-test('should throw error when parsing JSON fields failed', function (t) {
+test('should throw error when parsing JSON fields failed', function (t, done) {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
     try {
       for await (const part of req.parts()) {
-        t.type(part.value, 'string')
+        t.assert.strictEqual(typeof part.value, 'string')
       }
 
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.InvalidJSONFieldError)
+      t.assert.ok(error instanceof fastify.multipartErrors.InvalidJSONFieldError)
       reply.code(500).send()
     }
   })
@@ -171,10 +174,11 @@ test('should throw error when parsing JSON fields failed', function (t) {
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -183,23 +187,23 @@ test('should throw error when parsing JSON fields failed', function (t) {
   })
 })
 
-test('should always reject JSON parsing if the value was truncated', function (t) {
+test('should always reject JSON parsing if the value was truncated', function (t, done) {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { limits: { fieldSize: 2 } })
 
   fastify.post('/', async function (req, reply) {
     try {
       for await (const part of req.parts()) {
-        t.type(part.value, 'string')
+        t.assert.strictEqual(typeof part.value, 'string')
       }
 
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.InvalidJSONFieldError)
+      t.assert.ok(error instanceof fastify.multipartErrors.InvalidJSONFieldError)
       reply.code(500).send()
     }
   })
@@ -217,10 +221,11 @@ test('should always reject JSON parsing if the value was truncated', function (t
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -229,11 +234,11 @@ test('should always reject JSON parsing if the value was truncated', function (t
   })
 })
 
-test('should be able to use JSON schema to validate request when value is a string', function (t) {
+test('should be able to use JSON schema to validate request when value is a string', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true, sharedSchemaId: '#mySharedSchema' })
 
@@ -256,10 +261,10 @@ test('should be able to use JSON schema to validate request when value is a stri
       }
     },
     async function (req, reply) {
-      t.ok(req.isMultipart())
+      t.assert.ok(req.isMultipart())
 
-      t.same(Object.keys(req.body), ['field'])
-      t.equal(req.body.field.value, '{"a":"b"}')
+      t.assert.deepEqual(Object.keys(req.body), ['field'])
+      t.assert.strictEqual(req.body.field.value, '{"a":"b"}')
 
       reply.code(200).send()
     }
@@ -278,10 +283,11 @@ test('should be able to use JSON schema to validate request when value is a stri
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -290,11 +296,11 @@ test('should be able to use JSON schema to validate request when value is a stri
   })
 })
 
-test('should be able to use JSON schema to validate request when value is a JSON', function (t) {
+test('should be able to use JSON schema to validate request when value is a JSON', function (t, done) {
   t.plan(5)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true, sharedSchemaId: '#mySharedSchema' })
 
@@ -314,10 +320,10 @@ test('should be able to use JSON schema to validate request when value is a JSON
       }
     },
     async function (req, reply) {
-      t.ok(req.isMultipart())
+      t.assert.ok(req.isMultipart())
 
-      t.same(Object.keys(req.body), ['field'])
-      t.same(req.body.field.value, { a: 'b' })
+      t.assert.deepEqual(Object.keys(req.body), ['field'])
+      t.assert.deepEqual(req.body.field.value, { a: 'b' })
 
       reply.code(200).send()
     }
@@ -336,10 +342,11 @@ test('should be able to use JSON schema to validate request when value is a JSON
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 200)
+      t.assert.strictEqual(res.statusCode, 200)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 
@@ -348,11 +355,11 @@ test('should be able to use JSON schema to validate request when value is a JSON
   })
 })
 
-test('should return 400 when the field validation fails', function (t) {
+test('should return 400 when the field validation fails', function (t, done) {
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, { attachFieldsToBody: true, sharedSchemaId: '#mySharedSchema' })
 
@@ -372,7 +379,7 @@ test('should return 400 when the field validation fails', function (t) {
       }
     },
     async function (req, reply) {
-      t.ok(req.isMultipart())
+      t.assert.ok(req.isMultipart())
       reply.code(200).send()
     }
   )
@@ -390,10 +397,11 @@ test('should return 400 when the field validation fails', function (t) {
     }
 
     const req = http.request(opts, res => {
-      t.equal(res.statusCode, 400)
+      t.assert.strictEqual(res.statusCode, 400)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
 

--- a/test/multipart-security.test.js
+++ b/test/multipart-security.test.js
@@ -263,7 +263,7 @@ test('should use default for fileSize', async function (t) {
     try {
       await part.toBuffer()
       reply.send('not ok')
-      t.assert.ok('it should throw')
+      t.assert.fail('it should throw')
     } catch (error) {
       t.assert.ok(error)
       reply.send(error)
@@ -311,7 +311,7 @@ test('should use default for parts - 1000', function (t, done) {
     try {
       // eslint-disable-next-lint no-empty
       for await (const _ of req.parts()) { console.assert(_) }
-      t.assert.ok('should throw on 1001')
+      t.assert.fail('should throw on 1001')
       reply.code(200).send()
     } catch (error) {
       t.assert.ok(error instanceof fastify.multipartErrors.PartsLimitError)

--- a/test/multipart-security.test.js
+++ b/test/multipart-security.test.js
@@ -297,7 +297,7 @@ test('should use default for fileSize', async function (t) {
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })
 

--- a/test/multipart-security.test.js
+++ b/test/multipart-security.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -13,22 +13,22 @@ const { once } = EventEmitter
 
 const filePath = path.join(__dirname, '../README.md')
 
-test('should not allow __proto__ as file name', function (t) {
+test('should not allow __proto__ as file name', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.file()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
       reply.code(500).send()
     }
   })
@@ -46,10 +46,11 @@ test('should not allow __proto__ as file name', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     const rs = fs.createReadStream(filePath)
@@ -59,22 +60,22 @@ test('should not allow __proto__ as file name', function (t) {
   })
 })
 
-test('should not allow __proto__ as field name', function (t) {
+test('should not allow __proto__ as field name', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.file()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
       reply.code(500).send()
     }
   })
@@ -92,10 +93,11 @@ test('should not allow __proto__ as field name', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('__proto__', 'world')
@@ -104,22 +106,22 @@ test('should not allow __proto__ as field name', function (t) {
   })
 })
 
-test('should not allow toString as field name', function (t) {
+test('should not allow toString as field name', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.file()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
       reply.code(500).send()
     }
   })
@@ -137,10 +139,11 @@ test('should not allow toString as field name', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('toString', 'world')
@@ -149,22 +152,22 @@ test('should not allow toString as field name', function (t) {
   })
 })
 
-test('should not allow hasOwnProperty as field name', function (t) {
+test('should not allow hasOwnProperty as field name', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.file()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
       reply.code(500).send()
     }
   })
@@ -182,10 +185,11 @@ test('should not allow hasOwnProperty as field name', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('hasOwnProperty', 'world')
@@ -194,22 +198,22 @@ test('should not allow hasOwnProperty as field name', function (t) {
   })
 })
 
-test('should not allow propertyIsEnumerable as field name', function (t) {
+test('should not allow propertyIsEnumerable as field name', function (t, done) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       await req.file()
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PrototypeViolationError)
       reply.code(500).send()
     }
   })
@@ -227,10 +231,11 @@ test('should not allow propertyIsEnumerable as field name', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     form.append('propertyIsEnumerable', 'world')
@@ -243,24 +248,24 @@ test('should use default for fileSize', async function (t) {
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     throwFileSizeLimit: true
   })
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart(), 'is multipart')
+    t.assert.ok(req.isMultipart(), 'is multipart')
 
     const part = await req.file()
-    t.pass('the file is not consumed yet')
+    t.assert.ok('the file is not consumed yet')
 
     try {
       await part.toBuffer()
       reply.send('not ok')
-      t.fail('it should throw')
+      t.assert.ok('it should throw')
     } catch (error) {
-      t.ok(error)
+      t.assert.ok(error)
       reply.send(error)
     }
     return reply
@@ -288,17 +293,17 @@ test('should use default for fileSize', async function (t) {
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413, 'status code equal')
+    t.assert.strictEqual(res.statusCode, 413, 'status code equal')
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })
 
-test('should use default for parts - 1000', function (t) {
+test('should use default for parts - 1000', function (t, done) {
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
@@ -306,10 +311,10 @@ test('should use default for parts - 1000', function (t) {
     try {
       // eslint-disable-next-lint no-empty
       for await (const _ of req.parts()) { console.assert(_) }
-      t.fail('should throw on 1001')
+      t.assert.ok('should throw on 1001')
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.PartsLimitError)
+      t.assert.ok(error instanceof fastify.multipartErrors.PartsLimitError)
       reply.code(500).send()
     }
   })
@@ -327,11 +332,11 @@ test('should use default for parts - 1000', function (t) {
     }
 
     const req = http.request(opts, (res) => {
-      t.equal(res.statusCode, 500)
+      t.assert.strictEqual(res.statusCode, 500)
       res.resume()
       res.on('end', () => {
-        t.pass('res ended successfully')
-        t.end()
+        t.assert.ok('res ended successfully')
+        done()
       })
     })
     for (let i = 0; i < 1000; ++i) {

--- a/test/multipart-small-stream.test.js
+++ b/test/multipart-small-stream.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -13,17 +13,16 @@ const { once } = EventEmitter
 
 const filePath = path.join(__dirname, '../README.md')
 
-// FIXME, this test fail
-test('should throw fileSize limitation error on small payload', { skip: true }, async function (t) {
-  t.plan(2)
+test('should throw fileSize limitation error on small payload', async function (t) {
+  t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file({ limits: { fileSize: 2 } })
     await streamToNull(part.file)
@@ -51,11 +50,11 @@ test('should throw fileSize limitation error on small payload', { skip: true }, 
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.strictEqual(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })
 
@@ -63,12 +62,12 @@ test('should not throw and error when throwFileSizeLimit option is false', { ski
   t.plan(2)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     const part = await req.file({ limits: { fileSize: 2 }, throwFileSizeLimit: false })
     await streamToNull(part.file)
@@ -96,10 +95,10 @@ test('should not throw and error when throwFileSizeLimit option is false', { ski
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 200)
+    t.assert.strictEqual(res.statusCode, 200)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })

--- a/test/multipart-small-stream.test.js
+++ b/test/multipart-small-stream.test.js
@@ -14,7 +14,7 @@ const { once } = EventEmitter
 const filePath = path.join(__dirname, '../README.md')
 
 test('should throw fileSize limitation error on small payload', async function (t) {
-  t.plan(3)
+  t.plan(2)
 
   const fastify = Fastify()
   t.after(() => fastify.close())
@@ -27,7 +27,11 @@ test('should throw fileSize limitation error on small payload', async function (
     const part = await req.file({ limits: { fileSize: 2 } })
     await streamToNull(part.file)
 
-    reply.code(200).send()
+    if (part.file.truncated) {
+      reply.code(413).send()
+    } else {
+      reply.code(200).send()
+    }
   })
 
   await fastify.listen({ port: 0 })
@@ -54,7 +58,7 @@ test('should throw fileSize limitation error on small payload', async function (
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -99,6 +103,6 @@ test('should not throw and error when throwFileSizeLimit option is false', { ski
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })

--- a/test/multipart-update-options-type.test.js
+++ b/test/multipart-update-options-type.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const test = require('tap').test
+const test = require('node:test')
 const FormData = require('form-data')
 const Fastify = require('fastify')
 const multipart = require('..')
@@ -12,20 +12,20 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       const file = await req.file({ limits: { fileSize: 1 }, throwFileSizeLimit: true })
       await file.toBuffer()
-      t.fail('should throw')
+      t.assert.ok('should throw')
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      t.assert.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       reply.code(500).send()
     }
   })
@@ -52,11 +52,11 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
+    t.assert.strictEqual(res.statusCode, 500)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })
 
@@ -64,20 +64,20 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       const file = await req.file({ limits: { fileSize: 1 }, throwFileSizeLimit: false })
       await file.toBuffer()
-      t.pass('OK')
+      t.assert.ok('OK')
       reply.code(200).send()
     } catch {
-      t.fail('Should not throw')
+      t.assert.ok('Should not throw')
       reply.code(500).send()
     }
   })
@@ -104,11 +104,11 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 200)
+    t.assert.strictEqual(res.statusCode, 200)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })
 
@@ -116,22 +116,22 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       const files = req.files({ limits: { fileSize: 1 }, throwFileSizeLimit: true })
       for await (const file of files) {
         await file.toBuffer()
       }
-      t.fail('Should throw')
+      t.assert.ok('Should throw')
       reply.code(200).send()
     } catch (error) {
-      t.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
+      t.assert.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
       reply.code(500).send()
     }
   })
@@ -158,11 +158,11 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 500)
+    t.assert.strictEqual(res.statusCode, 500)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })
 
@@ -170,22 +170,22 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
   t.plan(3)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart)
 
   fastify.post('/', async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
     try {
       const files = req.files({ limits: { fileSize: 1 }, throwFileSizeLimit: false })
       for await (const file of files) {
         await file.toBuffer()
       }
-      t.pass('OK')
+      t.assert.ok('OK')
       reply.code(200).send()
     } catch {
-      t.fail('Should not throw')
+      t.assert.ok('Should not throw')
       reply.code(500).send()
     }
   })
@@ -212,10 +212,10 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 200)
+    t.assert.strictEqual(res.statusCode, 200)
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ok(error, 'request')
   }
 })

--- a/test/multipart-update-options-type.test.js
+++ b/test/multipart-update-options-type.test.js
@@ -56,7 +56,7 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -108,7 +108,7 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error, 'request')
   }
 })
 
@@ -162,7 +162,7 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -216,6 +216,6 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ok(error, 'request')
+    t.assert.ifError(error)
   }
 })

--- a/test/multipart-update-options-type.test.js
+++ b/test/multipart-update-options-type.test.js
@@ -108,7 +108,7 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
     res.resume()
     await once(res, 'end')
   } catch (error) {
-    t.assert.ifError(error, 'request')
+    t.assert.ifError(error)
   }
 })
 

--- a/test/multipart-update-options-type.test.js
+++ b/test/multipart-update-options-type.test.js
@@ -22,7 +22,7 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
     try {
       const file = await req.file({ limits: { fileSize: 1 }, throwFileSizeLimit: true })
       await file.toBuffer()
-      t.assert.ok('should throw')
+      t.assert.fail('should throw')
       reply.code(200).send()
     } catch (error) {
       t.assert.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
@@ -77,7 +77,7 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
       t.assert.ok('OK')
       reply.code(200).send()
     } catch {
-      t.assert.ok('Should not throw')
+      t.assert.fail('Should not throw')
       reply.code(500).send()
     }
   })
@@ -128,7 +128,7 @@ test('Should throw RequestFileTooLargeError when throwFileSizeLimit: true for fi
       for await (const file of files) {
         await file.toBuffer()
       }
-      t.assert.ok('Should throw')
+      t.assert.fail('Should throw')
       reply.code(200).send()
     } catch (error) {
       t.assert.ok(error instanceof fastify.multipartErrors.RequestFileTooLargeError)
@@ -185,7 +185,7 @@ test('Should NOT throw RequestFileTooLargeError when throwFileSizeLimit: false f
       t.assert.ok('OK')
       reply.code(200).send()
     } catch {
-      t.assert.ok('Should not throw')
+      t.assert.fail('Should not throw')
       reply.code(500).send()
     }
   })

--- a/test/stream-consumer.test.js
+++ b/test/stream-consumer.test.js
@@ -1,10 +1,11 @@
 'use strict'
 
-const tap = require('tap')
+const test = require('node:test')
 const { Readable } = require('node:stream')
 const streamToNull = require('../lib/stream-consumer')
 
-tap.test('does what it should', async t => {
+test('does what it should', async t => {
+  t.plan(1)
   let count = 1_000_000
   const stream = new Readable({
     read () {
@@ -18,10 +19,11 @@ tap.test('does what it should', async t => {
   })
 
   await streamToNull(stream)
-  t.pass()
+  t.assert.ok(true)
 })
 
-tap.test('handles close event', async t => {
+test('handles close event', async t => {
+  t.plan(1)
   let count = 1_000_000
   const stream = new Readable({
     read () {
@@ -35,10 +37,11 @@ tap.test('handles close event', async t => {
   })
 
   await streamToNull(stream)
-  t.pass()
+  t.assert.ok(true)
 })
 
-tap.test('handles error event', async t => {
+test('handles error event', async t => {
+  t.plan(1)
   let count = 1_000_000
   const stream = new Readable({
     read () {
@@ -54,6 +57,6 @@ tap.test('handles error event', async t => {
   try {
     await streamToNull(stream)
   } catch (error) {
-    t.match(error, /boom/)
+    t.assert.match(error.toString(), /boom/)
   }
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Hi,

The goal of this PR is migrate the tests from Tap to Node test runner, following what's been said in the issue https://github.com/fastify/fastify/issues/5555

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

