### PR TITLE
feat: add per route busboy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,20 @@ fastify.post('/', async function (req, reply) {
 })
 ```
 
+Or to a route options when `attachFieldsToBody` is used.
+```js
+fastify.post('/', {
+  config: {
+      multipartOptions: {
+        limits: { fileSize: 1000 }
+      }
+    }
+}, async function (req, reply) {
+  const buffer = req.body.file.toBuffer();
+  reply.send()
+})
+```
+
 ## Handle multiple file streams
 
 ```js

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function fastifyMultipart (fastify, options, done) {
         return
       }
 
-      for await (const part of req.parts(req.routeOptions.config.multipart_options)) {
+      for await (const part of req.parts(req.routeOptions.config.multipartOptions)) {
         req.body = part.fields
 
         if (part.file) {

--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function fastifyMultipart (fastify, options, done) {
         return
       }
 
-      for await (const part of req.parts()) {
+      for await (const part of req.parts(req.routeOptions.config.multipart_options)) {
         req.body = part.fields
 
         if (part.file) {

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -327,14 +327,14 @@ test('should throw fileSize limitation error when used alongside attachFieldsToB
     attachFieldsToBody: true
   })
 
-  const randomFileBuffer = Buffer.alloc(2_000_000)
+  const randomFileBuffer = Buffer.alloc(900_000)
   crypto.randomFillSync(randomFileBuffer)
 
   fastify.post('/', {
     config: {
       multipartOptions: {
         limits: {
-          fileSize: 1_000_000
+          fileSize: 800_000
         }
       }
     }

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -339,7 +339,7 @@ test('should throw fileSize limitation error when used alongside attachFieldsToB
       }
     }
   }, async function (req, reply) {
-    t.fail('it should throw')
+    t.assert.fail('it should throw')
 
     reply.status(200).send()
   })

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -316,3 +316,127 @@ test('should NOT throw fileSize limitation error when throwFileSizeLimit is glob
     t.error(error, 'request')
   }
 })
+
+test('should throw fileSize limitation error when used alongside attachFieldsToBody and set request config', async function (t) {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, {
+    attachFieldsToBody: true
+  })
+
+  const randomFileBuffer = Buffer.alloc(2_000_000)
+  crypto.randomFillSync(randomFileBuffer)
+
+  fastify.post('/', {
+    config: {
+      multipartOptions: {
+        limits: {
+          fileSize: 1_000_000
+        }
+      }
+    }
+  }, async function (req, reply) {
+    t.fail('it should throw')
+
+    reply.status(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    hostname: '127.0.0.1',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const tmpFile = 'test/random-file'
+  fs.writeFileSync(tmpFile, randomFileBuffer)
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(tmpFile))
+
+  form.pipe(req)
+
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 413)
+    res.resume()
+    await once(res, 'end')
+
+    fs.unlinkSync(tmpFile)
+  } catch (error) {
+    t.error(error, 'request')
+  }
+})
+
+test('should not throw fileSize limitation error when used alongside attachFieldsToBody and set request config', async function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.register(multipart, {
+    attachFieldsToBody: true
+  })
+
+  const randomFileBuffer = Buffer.alloc(900_000)
+  crypto.randomFillSync(randomFileBuffer)
+
+  fastify.post('/', {
+    config: {
+      multipartOptions: {
+        limits: {
+          fileSize: 1_000_000
+        }
+      }
+    }
+  }, async function (req, reply) {
+    t.ok(req.isMultipart())
+
+    t.same(Object.keys(req.body), ['upload'])
+
+    const content = await req.body.upload.toBuffer()
+
+    t.equal(content.toString(), randomFileBuffer.toString())
+
+    reply.status(200).send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // request
+  const form = new FormData()
+  const opts = {
+    hostname: '127.0.0.1',
+    port: fastify.server.address().port,
+    path: '/',
+    headers: form.getHeaders(),
+    method: 'POST'
+  }
+
+  const tmpFile = 'test/random-file'
+  fs.writeFileSync(tmpFile, randomFileBuffer)
+
+  const req = http.request(opts)
+  form.append('upload', fs.createReadStream(tmpFile))
+
+  form.pipe(req)
+
+  try {
+    const [res] = await once(req, 'response')
+    t.equal(res.statusCode, 200)
+    res.resume()
+    await once(res, 'end')
+
+    fs.unlinkSync(tmpFile)
+  } catch (error) {
+    t.error(error, 'request')
+  }
+})

--- a/test/multipart-fileLimit.test.js
+++ b/test/multipart-fileLimit.test.js
@@ -321,7 +321,7 @@ test('should throw fileSize limitation error when used alongside attachFieldsToB
   t.plan(1)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     attachFieldsToBody: true
@@ -366,13 +366,13 @@ test('should throw fileSize limitation error when used alongside attachFieldsToB
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 413)
+    t.assert.equal(res.statusCode, 413)
     res.resume()
     await once(res, 'end')
 
     fs.unlinkSync(tmpFile)
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error)
   }
 })
 
@@ -380,7 +380,7 @@ test('should not throw fileSize limitation error when used alongside attachField
   t.plan(4)
 
   const fastify = Fastify()
-  t.teardown(fastify.close.bind(fastify))
+  t.after(() => fastify.close())
 
   fastify.register(multipart, {
     attachFieldsToBody: true
@@ -398,13 +398,13 @@ test('should not throw fileSize limitation error when used alongside attachField
       }
     }
   }, async function (req, reply) {
-    t.ok(req.isMultipart())
+    t.assert.ok(req.isMultipart())
 
-    t.same(Object.keys(req.body), ['upload'])
+    t.assert.deepStrictEqual(Object.keys(req.body), ['upload'])
 
     const content = await req.body.upload.toBuffer()
 
-    t.equal(content.toString(), randomFileBuffer.toString())
+    t.assert.strictEqual(content.toString(), randomFileBuffer.toString())
 
     reply.status(200).send()
   })
@@ -431,12 +431,12 @@ test('should not throw fileSize limitation error when used alongside attachField
 
   try {
     const [res] = await once(req, 'response')
-    t.equal(res.statusCode, 200)
+    t.assert.equal(res.statusCode, 200)
     res.resume()
     await once(res, 'end')
 
     fs.unlinkSync(tmpFile)
   } catch (error) {
-    t.error(error, 'request')
+    t.assert.ifError(error)
   }
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -35,6 +35,10 @@ declare module 'fastify' {
   interface FastifyInstance {
     multipartErrors: MultipartErrors;
   }
+
+  interface FastifyContextConfig {
+    multipart_options?: Omit<BusboyConfig, 'headers'>
+  }
 }
 
 type FastifyMultipartPlugin = FastifyPluginCallback<

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,7 +37,7 @@ declare module 'fastify' {
   }
 
   interface FastifyContextConfig {
-    multipart_options?: Omit<BusboyConfig, 'headers'>
+    multipartOptions?: Omit<BusboyConfig, 'headers'>
   }
 }
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -184,13 +184,11 @@ const runServer = async () => {
       multipartOptions: {}
     }
   }, async function (req, reply) {
-    req.routeOptions.config.multipartOptions
     expectType<Omit<BusboyConfig, 'headers'>>(req.routeOptions.config.multipartOptions)
     reply.send()
   })
 
   app.post('/upload/files', async function (req, reply) {
-    req.routeOptions.config.multipartOptions
     expectError<Omit<BusboyConfig, 'headers'>>(req.routeOptions.config?.multipartOptions)
     reply.send()
   })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -179,6 +179,22 @@ const runServer = async () => {
     reply.send()
   })
 
+  app.post('/upload/files', {
+    config: {
+      multipartOptions: {}
+    }
+  }, async function (req, reply) {
+    req.routeOptions.config.multipartOptions
+    expectType<Omit<BusboyConfig, 'headers'>>(req.routeOptions.config.multipartOptions)
+    reply.send()
+  })
+
+  app.post('/upload/files', async function (req, reply) {
+    req.routeOptions.config.multipartOptions
+    expectError<Omit<BusboyConfig, 'headers'>>(req.routeOptions.config?.multipartOptions)
+    reply.send()
+  })
+
   await app.ready()
 }
 


### PR DESCRIPTION
There was a need to restrict the file size in each route when used alongside attachFieldsToBody. These changes will enable route-specific busboy configuration.
Example
```ts
fastify.post('/', {
    schema: {
        consumes: ['multipart/form-data'],
        body: Type.Object({
            // file: {isFile: true} as unknown as TSchema
            file: Type.Unsafe<{ toBuffer: () => Promise<Buffer> }>({ isFile: true })
        }),
        response: {
            200: Type.Object({
                ok: Type.Boolean()
            })
        }
    },
    config: {
        multipart_options: {
            limits: {
                fileSize: 1024*1024*2 // 2MB
            }
        }
    }
}, async (req, rep) => {
    const buf = req.body.file.toBuffer();
    return { ok: true }
})
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
