### PR TITLE
fix(deps): move `c8` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "@fastify/busboy": "^3.0.0",
     "@fastify/deepmerge": "^3.0.0",
     "@fastify/error": "^4.0.0",
-    "c8": "^10.1.3",
     "fastify-plugin": "^5.0.0",
     "secure-json-parse": "^4.0.0"
   },
@@ -19,6 +18,7 @@
     "@fastify/swagger-ui": "^5.0.0",
     "@types/node": "^24.0.8",
     "benchmark": "^2.1.4",
+    "c8": "^10.1.3",
     "climem": "^2.0.0",
     "concat-stream": "^2.0.0",
     "eslint": "^9.17.0",


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

`c8` was added as a project dependency in https://github.com/fastify/fastify-multipart/pull/573,  
but it should instead be listed under `devDependencies`. 

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included (N/A)
- [ ] documentation is changed or added (N/A)
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
