### PR TITLE
fix(types): correct ajvFilePlugin return type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -200,7 +200,7 @@ declare namespace fastifyMultipart {
   /**
    * Adds a new type `isFile` to help @fastify/swagger generate the correct schema.
    */
-  export function ajvFilePlugin (ajv: any): void
+  export function ajvFilePlugin (ajv: any): any
 
   export const fastifyMultipart: FastifyMultipartPlugin
   export { fastifyMultipart as default }


### PR DESCRIPTION
The \`ajvFilePlugin\` function returns \`ajv.addKeyword()\` which returns the Ajv instance, but the type declaration says it returns \`void\`. This breaks TypeScript when passing it to Fastify's \`ajv.plugins\` option since the \`Plugin\` type expects an \`Ajv\` return.

Changed the return type from \`void\` to \`any\` to match the actual runtime behavior and fix compatibility with Fastify's plugin type.

Fixes #605

#### Checklist

- [x] run \`npm run test && npm run benchmark --if-present\`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)