### PR TITLE
fix: expose InvalidJSONFieldError and NoFormData in multipartErrors

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,9 @@ function fastifyMultipart (fastify, options, done) {
     InvalidMultipartContentTypeError,
     RequestFileTooLargeError,
     FileBufferNotFoundError,
-    PrematureCloseError
+    PrematureCloseError,
+    InvalidJSONFieldError,
+    NoFormData
   })
 
   fastify.addContentTypeParser('multipart/form-data', setMultipart)

--- a/test/multipart-json.test.js
+++ b/test/multipart-json.test.js
@@ -141,7 +141,7 @@ test('should not parse JSON fields forms if non-json content-type is set', funct
 })
 
 test('should throw error when parsing JSON fields failed', function (t, done) {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   t.after(() => fastify.close())
@@ -188,7 +188,7 @@ test('should throw error when parsing JSON fields failed', function (t, done) {
 })
 
 test('should always reject JSON parsing if the value was truncated', function (t, done) {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   t.after(() => fastify.close())
@@ -407,5 +407,71 @@ test('should return 400 when the field validation fails', function (t, done) {
 
     form.append('field', JSON.stringify('abc'), { contentType: 'application/json' })
     form.pipe(req)
+  })
+})
+
+test('multipartErrors should expose InvalidJSONFieldError', async function (t) {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(multipart)
+  await fastify.ready()
+
+  t.assert.ok(fastify.multipartErrors.InvalidJSONFieldError, 'InvalidJSONFieldError is exposed on multipartErrors')
+  t.assert.strictEqual(typeof fastify.multipartErrors.InvalidJSONFieldError, 'function')
+})
+
+test('thrown InvalidJSONFieldError should be an instance of multipartErrors.InvalidJSONFieldError', function (t, done) {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    try {
+      for await (const part of req.parts()) {
+        t.assert.strictEqual(typeof part.value, 'string')
+      }
+      reply.code(200).send()
+    } catch (error) {
+      t.assert.ok(error instanceof fastify.multipartErrors.InvalidJSONFieldError)
+      t.assert.strictEqual(error.code, 'FST_INVALID_JSON_FIELD_ERROR')
+      reply.code(error.statusCode).send()
+    }
+  })
+
+  fastify.listen({ port: 0 }, function () {
+    const boundary = 'testboundary'
+    const body = [
+      '--' + boundary,
+      'Content-Disposition: form-data; name="jsonfield"',
+      'Content-Type: application/json',
+      '',
+      'not valid json',
+      '--' + boundary + '--',
+      ''
+    ].join('\r\n')
+
+    const opts = {
+      hostname: '127.0.0.1',
+      port: fastify.server.address().port,
+      path: '/',
+      method: 'POST',
+      headers: {
+        'content-type': 'multipart/form-data; boundary=' + boundary,
+        'content-length': Buffer.byteLength(body)
+      }
+    }
+
+    const req = http.request(opts, res => {
+      t.assert.strictEqual(res.statusCode, 406)
+      res.resume()
+      res.on('end', done)
+    })
+    req.end(body)
   })
 })

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,7 +62,10 @@ interface MultipartErrors {
   PrototypeViolationError: FastifyErrorConstructor;
   InvalidMultipartContentTypeError: FastifyErrorConstructor;
   RequestFileTooLargeError: FastifyErrorConstructor;
+  FileBufferNotFoundError: FastifyErrorConstructor;
   PrematureCloseError: FastifyErrorConstructor;
+  InvalidJSONFieldError: FastifyErrorConstructor;
+  NoFormData: FastifyErrorConstructor;
 }
 
 declare namespace fastifyMultipart {

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -165,7 +165,9 @@ const runServer = async () => {
 
     expect(app.multipartErrors.FieldsLimitError).type.toBe<FastifyErrorConstructor>()
     expect(app.multipartErrors.FilesLimitError).type.toBe<FastifyErrorConstructor>()
+    expect(app.multipartErrors.InvalidJSONFieldError).type.toBe<FastifyErrorConstructor>()
     expect(app.multipartErrors.InvalidMultipartContentTypeError).type.toBe<FastifyErrorConstructor>()
+    expect(app.multipartErrors.NoFormData).type.toBe<FastifyErrorConstructor>()
     expect(app.multipartErrors.PartsLimitError).type.toBe<FastifyErrorConstructor>()
     expect(app.multipartErrors.PrototypeViolationError).type.toBe<FastifyErrorConstructor>()
     expect(app.multipartErrors.RequestFileTooLargeError).type.toBe<FastifyErrorConstructor>()


### PR DESCRIPTION
## What

Two error constructors defined inside the plugin were missing from the `fastify.multipartErrors` decorator:

- `InvalidJSONFieldError` (code `FST_INVALID_JSON_FIELD_ERROR`) — thrown when a multipart field has `Content-Type: application/json` but carries invalid JSON
- `NoFormData` (code `FST_NO_FORM_DATA`) — thrown when `globalThis.FormData` is unavailable

The TypeScript `MultipartErrors` interface was also missing `FileBufferNotFoundError`, `InvalidJSONFieldError`, and `NoFormData`, leaving the type out of sync with the runtime.

## Why it matters

Users who want to branch on the error type idiomatically do:

```js
} catch (err) {
  if (err instanceof fastify.multipartErrors.InvalidJSONFieldError) { ... }
}
```

With `InvalidJSONFieldError` absent from `multipartErrors`, that check throws a `TypeError: Right-hand side of 'instanceof' is not callable` instead of returning `false`, which is a silent breakage. The error *is* thrown by the plugin with the documented code, but there was no way to reach its constructor through the public API.

## What changed

- `index.js`: add `InvalidJSONFieldError` and `NoFormData` to the `fastify.decorate('multipartErrors', …)` call
- `types/index.d.ts`: add `FileBufferNotFoundError`, `InvalidJSONFieldError`, and `NoFormData` to `MultipartErrors`
- `test/multipart-json.test.js`:
  - Fix `t.plan(2)` → `t.plan(3)` in two existing tests that were silently miscounted (the instanceof check was throwing a TypeError, skipping one assertion, and the wrong plan count went unnoticed)
  - Add a unit test confirming `multipartErrors.InvalidJSONFieldError` is a function and that an error thrown by the plugin is an instance of it

All tests pass (`npm test`) including TypeScript type checks.