### PR TITLE
fix(types): add optional value to MultipartFile for onFile

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -81,6 +81,11 @@ declare namespace fastifyMultipart {
 
   export interface MultipartFile {
     type: 'file';
+    /**
+     * A value can be assigned to a file part inside an `onFile` handler when
+     * using `attachFieldsToBody: 'keyValues'` to specify the decoded body value.
+     */
+    value?: unknown;
     toBuffer: () => Promise<Buffer>;
     file: BusboyFileStream;
     fieldname: string;

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -20,6 +20,7 @@ const runServer = async () => {
       parts: 500
     },
     onFile: (part: MultipartFile) => {
+      part.value = 'decoded'
       console.log(part)
     }
   })
@@ -73,7 +74,7 @@ const runServer = async () => {
     reply.send()
 
     expect(req.body.file.file).type.toBe<BusboyFileStream>()
-    expect(req.body.file).type.not.toHaveProperty('value')
+    expect(req.body.file).type.toHaveProperty('value')
   })
 
   // busboy


### PR DESCRIPTION
The README documents setting `part.value` inside an `onFile` handler when using
`attachFieldsToBody: 'keyValues'`, but `MultipartFile` has no `value` property, so that
example fails to typecheck with TS2339 (`Property 'value' does not exist on type 'MultipartFile'`).

Adds an optional `value?: unknown` to `MultipartFile`. `unknown` (not `any`) keeps it
type-safe and matches the existing `Record<string, unknown>` usage in this file; it's
optional because a file part only gets a `value` when one is assigned in `onFile`. Kept
`MultipartFile` non-generic to avoid rippling generics through `Multipart`/`MultipartFields`.

The existing type test asserted `req.body.file` had no `value`, so that assertion is flipped
and the `onFile` test handler now assigns `part.value` to cover the regression.

Fixes #574