### PR TITLE
fix: do not end parts() iteration while busboy still holds undelivered parts

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ const PrototypeViolationError = createError('FST_PROTO_VIOLATION', 'prototype pr
 const InvalidMultipartContentTypeError = createError('FST_INVALID_MULTIPART_CONTENT_TYPE', 'the request is not multipart', 406)
 const InvalidJSONFieldError = createError('FST_INVALID_JSON_FIELD_ERROR', 'a request field is not a valid JSON as declared by its Content-Type', 406)
 const FileBufferNotFoundError = createError('FST_FILE_BUFFER_NOT_FOUND', 'the file buffer was not found', 500)
+const PrematureCloseError = createError('FST_MP_PREMATURE_CLOSE', 'the request was closed before the multipart data was fully parsed', 400)
 const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 500)
 
 function setMultipart (req, _payload, done) {
@@ -179,7 +180,8 @@ function fastifyMultipart (fastify, options, done) {
     PrototypeViolationError,
     InvalidMultipartContentTypeError,
     RequestFileTooLargeError,
-    FileBufferNotFoundError
+    FileBufferNotFoundError,
+    PrematureCloseError
   })
 
   fastify.addContentTypeParser('multipart/form-data', setMultipart)
@@ -243,16 +245,8 @@ function fastifyMultipart (fastify, options, done) {
     const parts = () => {
       return new Promise((resolve, reject) => {
         handle((val) => {
-          if (val instanceof Error) {
-            if (val.message === 'Unexpected end of multipart data') {
-              // Stop parsing without throwing an error
-              resolve(null)
-            } else {
-              reject(val)
-            }
-          } else {
-            resolve(val)
-          }
+          if (val instanceof Error) return reject(val)
+          resolve(val)
         })
       })
     }
@@ -260,6 +254,7 @@ function fastifyMultipart (fastify, options, done) {
     const body = {}
     let lastError = null
     let currentFile = null
+    let sawData = false
     const request = this.raw
     const busboyOptions = deepmergeAll(
       { headers: request.headers },
@@ -270,7 +265,7 @@ function fastifyMultipart (fastify, options, done) {
     this.log.trace({ busboyOptions }, 'Providing options to busboy')
     const bb = busboy(busboyOptions)
 
-    request.on('close', cleanup)
+    request.on('close', onRequestClose)
     request.on('error', cleanup)
 
     bb
@@ -279,7 +274,7 @@ function fastifyMultipart (fastify, options, done) {
       .on('end', cleanup)
       .on('finish', cleanup)
       .on('close', cleanup)
-      .on('error', cleanup)
+      .on('error', onBusboyError)
 
     bb.on('partsLimit', function () {
       const err = new PartsLimitError()
@@ -299,7 +294,22 @@ function fastifyMultipart (fastify, options, done) {
       process.nextTick(() => cleanup(err))
     })
 
+    request.once('data', onFirstData)
     request.pipe(bb)
+
+    function onFirstData () {
+      sawData = true
+    }
+
+    function onBusboyError (err) {
+      // an empty body is treated as an empty form rather than as
+      // truncated multipart data
+      if (!sawData && err.message === 'Unexpected end of multipart data') {
+        cleanup()
+      } else {
+        cleanup(err)
+      }
+    }
 
     function onField (name, fieldValue, fieldnameTruncated, valueTruncated, encoding, contentType) {
       // don't overwrite prototypes
@@ -412,6 +422,15 @@ function fastifyMultipart (fastify, options, done) {
         // Other errors are expected to be handled by the consumer of the stream
       })
 
+      // If the consumer destroys the file stream without reading it to the
+      // end, busboy stops parsing and will never emit 'finish', so the
+      // iteration has to end here (with the last error, if there is one)
+      file.on('close', function () {
+        if (!file.readableEnded) {
+          cleanup()
+        }
+      })
+
       if (throwFileSizeLimit) {
         file.on('limit', function () {
           const err = new RequestFileTooLargeError()
@@ -434,6 +453,16 @@ function fastifyMultipart (fastify, options, done) {
     function onError (err) {
       lastError = err
       currentFile = null
+    }
+
+    function onRequestClose () {
+      // 'close' on a completed request says nothing about parts busboy is
+      // still holding: they must keep flowing and iteration ends on busboy's
+      // own end events. A premature close has to end iteration here though,
+      // as busboy will never emit 'finish' for a truncated stream.
+      if (!request.readableEnded) {
+        cleanup(lastError || new PrematureCloseError())
+      }
     }
 
     function cleanup (err) {

--- a/test/fix-630.test.js
+++ b/test/fix-630.test.js
@@ -1,0 +1,216 @@
+'use strict'
+
+const test = require('node:test')
+const Fastify = require('fastify')
+const multipart = require('..')
+const http = require('node:http')
+const net = require('node:net')
+const { once } = require('node:events')
+const { setTimeout: sleep } = require('node:timers/promises')
+
+const BOUNDARY = 'fix630boundary'
+
+function filePart (fieldname, filename, payload) {
+  return Buffer.concat([
+    Buffer.from(
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="${fieldname}"; filename="${filename}"\r\n` +
+      'Content-Type: application/octet-stream\r\n\r\n'
+    ),
+    payload,
+    Buffer.from('\r\n')
+  ])
+}
+
+function fieldPart (fieldname, value) {
+  return Buffer.from(
+    `--${BOUNDARY}\r\n` +
+    `Content-Disposition: form-data; name="${fieldname}"\r\n\r\n` +
+    `${value}\r\n`
+  )
+}
+
+const closingBoundary = Buffer.from(`--${BOUNDARY}--\r\n`)
+
+// Reproduces https://github.com/fastify/fastify-multipart/issues/630
+// The request emits 'close' once its body is fully piped into busboy,
+// which can happen while the consumer is still slowly reading an earlier
+// file part and busboy is still holding undelivered parts. Those trailing
+// parts must still be yielded instead of being cut off by the end marker.
+test('parts() delivers trailing parts even when the request closes while busboy still buffers them', async function (t) {
+  t.plan(2)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  // a large busboy highWaterMark lets the whole request body drain into
+  // busboy's writable buffer at once, so the request emits 'close' while
+  // busboy still holds undelivered parts. The same ordering happens with
+  // the default highWaterMark when a proxy re-segments the stream.
+  fastify.register(multipart, { highWaterMark: 2 * 1024 * 1024 })
+
+  fastify.post('/', async function (req) {
+    const seen = []
+    for await (const part of req.parts()) {
+      if (part.type === 'file') {
+        let size = 0
+        for await (const chunk of part.file) {
+          size += chunk.length
+          // simulate a slow storage write so the request finishes piping
+          // (and emits 'close') while we are still consuming this file
+          await sleep(10)
+        }
+        seen.push({ type: 'file', fieldname: part.fieldname, size })
+      } else {
+        seen.push({ type: 'field', fieldname: part.fieldname })
+      }
+    }
+    return { seen }
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const image = Buffer.alloc(200 * 1024, 'a')
+  const mask = Buffer.alloc(6 * 1024, 'b')
+  const body = Buffer.concat([
+    filePart('file', 'image.bin', image),
+    filePart('mask', 'mask.bin', mask),
+    fieldPart('clientJobId', 'job-1'),
+    fieldPart('format', 'png'),
+    fieldPart('quality', '90'),
+    closingBoundary
+  ])
+
+  const req = http.request({
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-type': `multipart/form-data; boundary=${BOUNDARY}`,
+      'content-length': body.length
+    }
+  })
+  req.end(body)
+
+  const [res] = await once(req, 'response')
+  t.assert.strictEqual(res.statusCode, 200)
+
+  const chunks = []
+  for await (const chunk of res) {
+    chunks.push(chunk)
+  }
+  const { seen } = JSON.parse(Buffer.concat(chunks))
+  t.assert.deepStrictEqual(seen, [
+    { type: 'file', fieldname: 'file', size: image.length },
+    { type: 'file', fieldname: 'mask', size: mask.length },
+    { type: 'field', fieldname: 'clientJobId' },
+    { type: 'field', fieldname: 'format' },
+    { type: 'field', fieldname: 'quality' }
+  ])
+})
+
+test('parts() rejects when the multipart data is truncated instead of ending cleanly', async function (t) {
+  t.plan(3)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(multipart)
+
+  fastify.post('/', async function (req, reply) {
+    try {
+      for await (const part of req.parts()) {
+        if (part.file) {
+          await part.toBuffer()
+        }
+      }
+    } catch (err) {
+      t.assert.strictEqual(err.message, 'Unexpected end of multipart data')
+      return reply.code(400).send({ error: 'truncated' })
+    }
+    return reply.send({ error: 'iteration ended cleanly' })
+  })
+
+  await fastify.listen({ port: 0 })
+
+  // a complete first part but no closing boundary: the request body ends
+  // normally at the HTTP layer while the multipart data is truncated
+  const body = Buffer.concat([
+    filePart('file', 'image.bin', Buffer.alloc(1024, 'a')),
+    fieldPart('clientJobId', 'job-1')
+  ])
+
+  const req = http.request({
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-type': `multipart/form-data; boundary=${BOUNDARY}`,
+      'content-length': body.length
+    }
+  })
+  req.end(body)
+
+  const [res] = await once(req, 'response')
+  t.assert.strictEqual(res.statusCode, 400)
+  res.resume()
+  await once(res, 'end')
+  t.assert.ok('request completed')
+})
+
+test('parts() rejects when the client aborts mid-upload instead of ending cleanly', async function (t) {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(multipart)
+
+  let handled
+  const handledPromise = new Promise((resolve) => { handled = resolve })
+
+  fastify.post('/', async function (req, reply) {
+    try {
+      for await (const part of req.parts()) {
+        if (part.file) {
+          for await (const chunk of part.file) {
+            chunk.toString()
+          }
+        }
+      }
+      handled({ outcome: 'clean end' })
+    } catch (err) {
+      handled({ outcome: 'error', message: err.message })
+    }
+    return reply.send()
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const body = Buffer.concat([
+    filePart('file', 'image.bin', Buffer.alloc(64 * 1024, 'a')),
+    fieldPart('clientJobId', 'job-1'),
+    closingBoundary
+  ])
+
+  const socket = net.connect(fastify.server.address().port, 'localhost')
+  await once(socket, 'connect')
+  socket.write(
+    'POST / HTTP/1.1\r\n' +
+    'Host: localhost\r\n' +
+    `Content-Type: multipart/form-data; boundary=${BOUNDARY}\r\n` +
+    `Content-Length: ${body.length}\r\n` +
+    '\r\n'
+  )
+  // send only part of the body, then abort the connection
+  socket.write(body.subarray(0, 16 * 1024))
+  await sleep(100)
+  socket.destroy()
+
+  const result = await handledPromise
+  t.assert.strictEqual(result.outcome, 'error', `iteration must reject on abort, got: ${JSON.stringify(result)}`)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -62,6 +62,7 @@ interface MultipartErrors {
   PrototypeViolationError: FastifyErrorConstructor;
   InvalidMultipartContentTypeError: FastifyErrorConstructor;
   RequestFileTooLargeError: FastifyErrorConstructor;
+  PrematureCloseError: FastifyErrorConstructor;
 }
 
 declare namespace fastifyMultipart {


### PR DESCRIPTION
## Summary

Fixes #630.

`request.on('close')` fires once the message body has fully drained into busboy's writable buffer. Busboy defers its write ack when a file stream backs up, so on a fast/re-segmented connection the request can complete while busboy still holds parsed-but-undelivered parts. The `cleanup` bound to `close` pushed the end marker into the same queue the parts flow through, and every part emitted afterwards landed behind it — trailing file parts and fields were silently lost, exactly as reported.

## Changes

- **End iteration on busboy's own end events.** `request.on('close')` only terminates the iteration when the message did **not** complete (`readableEnded === false`, i.e. a client abort), and then with a new `PrematureCloseError` (`FST_MP_PREMATURE_CLOSE`, exposed via `fastify.multipartErrors` and the TypeScript types) instead of a silent clean end.
- **Surface `Unexpected end of multipart data` as an error.** The suppression came in mechanically with the busboy v2.1.0 upgrade (#506); it made truncated uploads indistinguishable from complete ones. A fully empty body (zero bytes received) is still treated as an empty form, preserving the behavior pinned by `multipart-empty-body.test.js`.
- **End iteration when the consumer destroys a file stream without reading it to the end.** Busboy never emits `finish` in that case; previously the `close`-based cleanup masked this, and without a guard `parts()` would hang forever (caught by the existing *should not freeze when error is thrown during processing* test).

## Reproduction / tests

Written TDD-style in `test/fix-630.test.js` (red on `main`, green here):

1. **Trailing parts survive early request `close`** — slow consumer, 200 KB file + 6 KB mask + three fields. A large busboy `highWaterMark` makes the failing event ordering deterministic on loopback (the same ordering the issue reproduced through Docker Desktop's port forwarding with default settings); on `main` the handler sees only the first file.
2. **Truncated multipart data rejects** with `Unexpected end of multipart data` instead of ending cleanly.
3. **Client abort mid-upload rejects the iterator** — guards that dropping the `close`-based cleanup doesn't reintroduce hangs on aborts.

## Behavioral note

Consumers that previously saw a clean-looking, silently-truncated iteration on truncated or aborted uploads now get an error — that is the point of the fix, but it may warrant a semver-major release.

## Checklist

- [x] run `npm run test` — 90/90 unit tests, 100 % coverage, tstyche 34/34
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added — no doc changes needed (error is exported via existing `multipartErrors` mechanism)
- [x] commit message follows commit guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)
