### PR TITLE
fix: parse multipart from the preParsing payload stream, not req.raw

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const { pipeline: pump } = require('node:stream/promises')
 const secureJSON = require('secure-json-parse')
 
 const kMultipart = Symbol('multipart')
+const kMultipartPayload = Symbol('multipartPayload')
 const kMultipartHandler = Symbol('multipartHandler')
 const kSavedRequestFilesResult = Symbol('savedRequestFilesResult')
 
@@ -29,8 +30,9 @@ const FileBufferNotFoundError = createError('FST_FILE_BUFFER_NOT_FOUND', 'the fi
 const PrematureCloseError = createError('FST_MP_PREMATURE_CLOSE', 'the request was closed before the multipart data was fully parsed', 400)
 const NoFormData = createError('FST_NO_FORM_DATA', 'FormData is not available', 500)
 
-function setMultipart (req, _payload, done) {
+function setMultipart (req, payload, done) {
   req[kMultipart] = true
+  req[kMultipartPayload] = payload
   done()
 }
 
@@ -186,6 +188,7 @@ function fastifyMultipart (fastify, options, done) {
 
   fastify.addContentTypeParser('multipart/form-data', setMultipart)
   fastify.decorateRequest(kMultipart, false)
+  fastify.decorateRequest(kMultipartPayload, null)
   fastify.decorateRequest(kMultipartHandler, handleMultipart)
   fastify.decorateRequest(kSavedRequestFilesResult, null)
 
@@ -255,9 +258,9 @@ function fastifyMultipart (fastify, options, done) {
     let lastError = null
     let currentFile = null
     let sawData = false
-    const request = this.raw
+    const request = this[kMultipartPayload]
     const busboyOptions = deepmergeAll(
-      { headers: request.headers },
+      { headers: this.headers },
       options,
       opts
     )

--- a/test/fix-620.test.js
+++ b/test/fix-620.test.js
@@ -1,0 +1,112 @@
+'use strict'
+
+const test = require('node:test')
+const Fastify = require('fastify')
+const http = require('node:http')
+const crypto = require('node:crypto')
+const { PassThrough } = require('node:stream')
+const { once } = require('node:events')
+const multipart = require('..')
+
+const BOUNDARY = 'fix620boundary'
+
+function fieldPart (fieldname, value) {
+  return Buffer.from(
+    `--${BOUNDARY}\r\n` +
+    `Content-Disposition: form-data; name="${fieldname}"\r\n\r\n` +
+    `${value}\r\n`
+  )
+}
+
+function filePart (fieldname, filename, payload) {
+  return Buffer.concat([
+    Buffer.from(
+      `--${BOUNDARY}\r\n` +
+      `Content-Disposition: form-data; name="${fieldname}"; filename="${filename}"\r\n` +
+      'Content-Type: application/octet-stream\r\n\r\n'
+    ),
+    payload,
+    Buffer.from('\r\n')
+  ])
+}
+
+const closingBoundary = Buffer.from(`--${BOUNDARY}--\r\n`)
+
+test('multipart parsing follows the stream returned by a preParsing hook', async function (t) {
+  t.plan(4)
+
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  fastify.register(multipart)
+
+  let digest
+
+  fastify.addHook('preParsing', async function (request, reply, payload) {
+    const clone = new PassThrough()
+    const hash = crypto.createHash('sha256')
+
+    payload.on('data', (chunk) => {
+      hash.update(chunk)
+      clone.write(chunk)
+    })
+    payload.on('end', () => {
+      digest = hash.digest('hex')
+      clone.end()
+    })
+    payload.on('error', (err) => clone.destroy(err))
+
+    return clone
+  })
+
+  fastify.post('/', async function (req) {
+    const seen = []
+    for await (const part of req.parts()) {
+      if (part.type === 'file') {
+        seen.push({ type: 'file', fieldname: part.fieldname, buf: (await part.toBuffer()).toString() })
+      } else {
+        seen.push({ type: 'field', fieldname: part.fieldname, value: part.value })
+      }
+    }
+    return { seen, digest }
+  })
+
+  await fastify.listen({ port: 0 })
+
+  const body = Buffer.concat([
+    fieldPart('clientJobId', 'job-1'),
+    filePart('file', 'hello.txt', Buffer.from('hello world')),
+    closingBoundary
+  ])
+
+  const expectedDigest = crypto.createHash('sha256').update(body).digest('hex')
+
+  const req = http.request({
+    protocol: 'http:',
+    hostname: 'localhost',
+    port: fastify.server.address().port,
+    path: '/',
+    method: 'POST',
+    headers: {
+      'content-type': `multipart/form-data; boundary=${BOUNDARY}`,
+      'content-length': body.length
+    }
+  })
+  req.end(body)
+
+  const [res] = await once(req, 'response')
+  t.assert.strictEqual(res.statusCode, 200)
+
+  const chunks = []
+  for await (const chunk of res) {
+    chunks.push(chunk)
+  }
+  const { seen, digest: receivedDigest } = JSON.parse(Buffer.concat(chunks))
+
+  t.assert.deepStrictEqual(seen, [
+    { type: 'field', fieldname: 'clientJobId', value: 'job-1' },
+    { type: 'file', fieldname: 'file', buf: 'hello world' }
+  ])
+  t.assert.strictEqual(receivedDigest, expectedDigest)
+  t.assert.ok(receivedDigest)
+})


### PR DESCRIPTION
## Summary

Fixes #620.

`handleMultipart` piped multipart data straight from `request.raw`, the
underlying Node.js request stream. Fastify, however, hands content-type
parsers a `payload` argument that is `request.raw` by default but gets
replaced whenever a `preParsing` hook returns a new stream (e.g. to tee
the body for webhook signature verification, as described in the issue).
Since this plugin ignored that replacement, a `preParsing` hook that
consumed the stream left `request.raw` already drained/closed by the time
busboy tried to read from it — so multipart parsing silently found an
empty body.

The fix captures the `payload` stream fastify already passes into the
`multipart/form-data` content-type parser and uses that (instead of
`request.raw`) when piping into busboy. When no `preParsing` hook touches
the stream, this is the same object as `request.raw`, so there's no
behavior change for existing users.

## Test plan

- Added `test/fix-620.test.js`: registers a `preParsing` hook that computes
  a SHA-256 digest over the raw body and hands off a replacement stream,
  then asserts multipart fields/files still parse correctly. Verified it
  fails against the pre-fix code (empty parts) and passes after the fix.
- `npm run test:unit` — 91/91 passing, 100% coverage.
- `npm run lint` — clean.
