### PR TITLE
docs: fix invalid multipart JSON schema example

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ fastify.post('/upload/files', {
             {
               properties: {
                 value: {
-                  type: 'object'
+                  type: 'object',
                   properties: {
                     child: {
                       type: 'string'


### PR DESCRIPTION
## Summary

- add the missing comma to the multipart JSON schema example
- make the documented JavaScript snippet syntactically valid